### PR TITLE
Clipping layers to bounds for MapboxGL rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ keyed by the layer name. For example:
 	layers := mvt.NewLayers(collections)
 	layers.ProjectToTile(maptile.New(x, y, z))
 
+    // In order to be used as source for MapboxGL geometries need to be clipped
+    // to max allowed extent. (uncomment next line)
+    // layers.Clip(mvt.MapboxGLDefaultExtentBound)
+
 	// Simplify the geometry now that it's in tile coordinate space.
 	layers.Simplify(simplify.DouglasPeucker(1.0))
 

--- a/encoding/mvt/README.md
+++ b/encoding/mvt/README.md
@@ -34,6 +34,10 @@ collections := map[string]*geojson.FeatureCollection{}
 layers := mvt.NewLayers(collections)
 layers.ProjectToTile(maptile.New(x, y, z))
 
+// In order to be used as source for MapboxGL geometries need to be clipped
+// to max allowed extent. (uncomment next line)
+// layers.Clip(mvt.MapboxGLDefaultExtentBound)
+
 // Simplify the geometry now that it's in the tile coordinate space.
 layers.Simplify(simplify.DouglasPeucker(1.0))
 

--- a/encoding/mvt/clip.go
+++ b/encoding/mvt/clip.go
@@ -1,0 +1,21 @@
+package mvt
+
+import (
+	"github.com/paulmach/orb"
+	"github.com/paulmach/orb/clip"
+)
+
+// Clip will clip all geometries in all layers to the given bounds.
+func (ls Layers) Clip(box orb.Bound) {
+	for _, l := range ls {
+		l.Clip(box)
+	}
+}
+
+// Clip will clip all geometries in this layer to the given bounds.
+func (l *Layer) Clip(box orb.Bound) {
+	for _, f := range l.Features {
+		g := clip.Geometry(box, f.Geometry)
+		f.Geometry = g
+	}
+}

--- a/encoding/mvt/clip.go
+++ b/encoding/mvt/clip.go
@@ -6,6 +6,8 @@ import (
 )
 
 var (
+	// Default mapbox vector tile bounds used by mapbox-gl.
+	// (https://www.mapbox.com/mapbox-gl-js/style-spec/#sources-vector)
 	MapboxGLDefaultExtentBound = orb.Bound{
 		Min: orb.Point{-1 * DefaultExtent, -1 * DefaultExtent},
 		Max: orb.Point{2*DefaultExtent - 1, 2*DefaultExtent - 1},

--- a/encoding/mvt/clip.go
+++ b/encoding/mvt/clip.go
@@ -5,6 +5,13 @@ import (
 	"github.com/paulmach/orb/clip"
 )
 
+var (
+	MapboxGLDefaultExtentBound = orb.Bound{
+		Min: orb.Point{-1 * DefaultExtent, -1 * DefaultExtent},
+		Max: orb.Point{2*DefaultExtent - 1, 2*DefaultExtent - 1},
+	}
+)
+
 // Clip will clip all geometries in all layers to the given bounds.
 func (ls Layers) Clip(box orb.Bound) {
 	for _, l := range ls {

--- a/encoding/mvt/clip.go
+++ b/encoding/mvt/clip.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	// Default mapbox vector tile bounds used by mapbox-gl.
+	// MapboxGLDefaultExtentBound holds the default mapbox vector tile bounds used by mapbox-gl.
 	// (https://www.mapbox.com/mapbox-gl-js/style-spec/#sources-vector)
 	MapboxGLDefaultExtentBound = orb.Bound{
 		Min: orb.Point{-1 * DefaultExtent, -1 * DefaultExtent},

--- a/encoding/mvt/clip_test.go
+++ b/encoding/mvt/clip_test.go
@@ -1,0 +1,58 @@
+package mvt
+
+import (
+	"github.com/paulmach/orb"
+	"github.com/paulmach/orb/geojson"
+	"reflect"
+	"testing"
+)
+
+func TestLayersClip(t *testing.T) {
+	cases := []struct {
+		name   string
+		bound  orb.Bound
+		input  Layers
+		output Layers
+	}{
+		{
+			name: "clips polygon and line",
+			input: Layers{&Layer{
+				Features: []*geojson.Feature{
+					geojson.NewFeature(orb.Polygon([]orb.Ring{
+						{
+							{-10, 10}, {0, 10}, {10, 10}, {10, 5}, {10, -5},
+							{10, -10}, {20, -10}, {20, 10}, {40, 10}, {40, 20},
+							{20, 20}, {20, 40}, {10, 40}, {10, 20}, {5, 20},
+							{-10, 20},
+						},
+					})),
+					geojson.NewFeature(orb.LineString{{-15, 0}, {66, 0}}),
+				},
+			}},
+			output: Layers{&Layer{
+				Features: []*geojson.Feature{
+					geojson.NewFeature(orb.Polygon([]orb.Ring{
+						{
+							{0, 10}, {0, 10}, {10, 10}, {10, 5}, {10, 0},
+							{20, 0}, {20, 10}, {30, 10}, {30, 20}, {20, 20},
+							{20, 30}, {10, 30}, {10, 20}, {5, 20}, {0, 20},
+						},
+					})),
+					geojson.NewFeature(orb.LineString{{0, 0}, {30, 0}}),
+				},
+			}},
+			bound: orb.Bound{Min: orb.Point{0, 0}, Max: orb.Point{30, 30}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.input.Clip(tc.bound)
+			if !reflect.DeepEqual(tc.input, tc.output) {
+				t.Errorf("incorrect clip")
+				t.Logf("%v", tc.input)
+				t.Logf("%v", tc.output)
+			}
+		})
+	}
+}

--- a/encoding/mvt/layer.go
+++ b/encoding/mvt/layer.go
@@ -6,6 +6,10 @@ import (
 	"github.com/paulmach/orb/project"
 )
 
+const (
+	DefaultExtent = 4096
+)
+
 // Layer is intermediate MVT layer to be encoded/decoded or projected.
 type Layer struct {
 	Name     string
@@ -20,7 +24,7 @@ func NewLayer(name string, fc *geojson.FeatureCollection) *Layer {
 	return &Layer{
 		Name:     name,
 		Version:  1,
-		Extent:   4096,
+		Extent:   DefaultExtent,
 		Features: fc.Features,
 	}
 }

--- a/encoding/mvt/layer.go
+++ b/encoding/mvt/layer.go
@@ -7,6 +7,7 @@ import (
 )
 
 const (
+	// Default extent for mapbox vector tiles. (https://www.mapbox.com/vector-tiles/specification/)
 	DefaultExtent = 4096
 )
 

--- a/encoding/mvt/layer.go
+++ b/encoding/mvt/layer.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	// Default extent for mapbox vector tiles. (https://www.mapbox.com/vector-tiles/specification/)
+	// DefaultExtent for mapbox vector tiles. (https://www.mapbox.com/vector-tiles/specification/)
 	DefaultExtent = 4096
 )
 


### PR DESCRIPTION
I think it is useful to have the clipping functionality directly on the layers. 
This allows you to easily create vector tiles that can be rendered using mapbox-gl. 
Otherwise it is not quite obvious that you need to do the clipping and you keep wondering why there are some rendering artifacts at times. At least thats what I experienced. ^^
(addresses #3)