### PR TITLE
geojson: have Feature implement the orb.Pointer interface

### DIFF
--- a/geojson/example_pointer_test.go
+++ b/geojson/example_pointer_test.go
@@ -1,0 +1,41 @@
+package geojson_test
+
+import (
+	"fmt"
+
+	"github.com/paulmach/orb"
+	"github.com/paulmach/orb/geojson"
+	"github.com/paulmach/orb/planar"
+	"github.com/paulmach/orb/quadtree"
+)
+
+type CentroidPoint struct {
+	*geojson.Feature
+}
+
+func (cp CentroidPoint) Point() orb.Point {
+	// this is where you would decide how to define
+	// the representative point of the feature.
+	c, _ := planar.CentroidArea(cp.Feature.Geometry)
+	return c
+}
+
+func main() {
+	qt := quadtree.New(orb.Bound{Min: orb.Point{0, 0}, Max: orb.Point{1, 1}})
+
+	// feature with center {0.5, 0.5} but centroid {0.25, 0.25}
+	f := geojson.NewFeature(orb.MultiPoint{{0, 0}, {0, 0}, {0, 0}, {1, 1}})
+	f.Properties["centroid"] = "0.25"
+	qt.Add(CentroidPoint{f})
+
+	// feature with centroid {0.6, 0.6}
+	f = geojson.NewFeature(orb.Point{0.6, 0.6})
+	f.Properties["centroid"] = "0.6"
+	qt.Add(CentroidPoint{f})
+
+	feature := qt.Find(orb.Point{0.5, 0.5}).(CentroidPoint).Feature
+	fmt.Printf("centroid=%s", feature.Properties["centroid"])
+
+	// Output:
+	// centroid=0.6
+}

--- a/geojson/example_test.go
+++ b/geojson/example_test.go
@@ -7,7 +7,24 @@ import (
 
 	"github.com/paulmach/orb"
 	"github.com/paulmach/orb/geojson"
+	"github.com/paulmach/orb/quadtree"
 )
+
+func ExampleFeature_Point() {
+	f := geojson.NewFeature(orb.Point{1, 1})
+	f.Properties["key"] = "value"
+
+	qt := quadtree.New(f.Geometry.Bound().Pad(1))
+	qt.Add(f) // add the feature to a quadtree
+
+	// type assert the feature back into a Feature from
+	// the orb.Pointer interface.
+	feature := qt.Find(orb.Point{0, 0}).(*geojson.Feature)
+	fmt.Printf("key=%s", feature.Properties["key"])
+
+	// Output:
+	// key=value
+}
 
 func ExampleFeatureCollection_foreignMembers() {
 	rawJSON := []byte(`

--- a/geojson/feature.go
+++ b/geojson/feature.go
@@ -24,6 +24,15 @@ func NewFeature(geometry orb.Geometry) *Feature {
 	}
 }
 
+// Point implements the orb.Pointer interface so that Features can be used
+// with quadtrees. The point returned is the center of the Bound of the geometry.
+// To represent the geometry with another point you must create a wrapper type.
+func (f *Feature) Point() orb.Point {
+	return f.Geometry.Bound().Center()
+}
+
+var _ orb.Pointer = &Feature{}
+
 // MarshalJSON converts the feature object into the proper JSON.
 // It will handle the encoding of all the child geometries.
 // Alternately one can call json.Marshal(f) directly for the same result.


### PR DESCRIPTION
Have the `geojson.Feature` type implement the `orb.Pointer` interface so it can be used directly in a quadtree.  Uses the center of the bound to define the point. For something else see the example on how to define a custom type.

Discussed in https://github.com/paulmach/orb/issues/7

@s8mathur