### PR TITLE
Support encoding/decoding uint64 feature IDs

### DIFF
--- a/encoding/mvt/marshal.go
+++ b/encoding/mvt/marshal.go
@@ -63,12 +63,15 @@ func Marshal(layers Layers) ([]byte, error) {
 				return nil, errors.WithMessage(err, fmt.Sprintf("layer %s: feature %d: error encoding geometry", l.Name, i))
 			}
 
+			id := f.ID
+
 			tags, err := encodeProperties(kve, f.Properties)
 			if err != nil {
 				return nil, errors.WithMessage(err, fmt.Sprintf("layer %s: feature %d: error encoding properties", l.Name, i))
 			}
 
 			layer.Features = append(layer.Features, &vectortile.Tile_Feature{
+				Id:       id,
 				Tags:     tags,
 				Type:     &t,
 				Geometry: g,
@@ -137,7 +140,7 @@ func decode(vt *vectortile.Tile) (Layers, error) {
 				}
 
 				if f.Id != nil {
-					gjf.ID = int(*f.Id)
+					gjf.ID = f.Id
 				}
 
 				layer.Features = append(layer.Features, gjf)

--- a/geojson/feature.go
+++ b/geojson/feature.go
@@ -9,7 +9,7 @@ import (
 
 // A Feature corresponds to GeoJSON feature object
 type Feature struct {
-	ID         interface{}  `json:"id,omitempty"`
+	ID         *uint64      `json:"id,omitempty"`
 	Type       string       `json:"type"`
 	BBox       BBox         `json:"bbox,omitempty"`
 	Geometry   orb.Geometry `json:"geometry"`
@@ -90,9 +90,9 @@ func (f *Feature) UnmarshalJSON(data []byte) error {
 }
 
 type jsonFeature struct {
-	ID         interface{} `json:"id,omitempty"`
-	Type       string      `json:"type"`
-	BBox       BBox        `json:"bbox,omitempty"`
-	Geometry   *Geometry   `json:"geometry"`
-	Properties Properties  `json:"properties"`
+	ID         *uint64    `json:"id,omitempty"`
+	Type       string     `json:"type"`
+	BBox       BBox       `json:"bbox,omitempty"`
+	Geometry   *Geometry  `json:"geometry"`
+	Properties Properties `json:"properties"`
 }


### PR DESCRIPTION
This hotfix allows feature IDs to be encoded and decoded properly, which is necessary to support functionality such as [MapBox GL's `setFeatureState(...)`](https://www.mapbox.com/mapbox-gl-js/api/#map#setfeaturestate) which relies on the feature ID to uniquely identify the feature. This also helps to better conform to the MapBox Vector Tile specification.

Note that previously, these values, though allowed in the `struct`s, were being omitted entirely in the encoder.