### PR TITLE
marshal geojson ids into mvt uint64 if possible

### DIFF
--- a/encoding/mvt/README.md
+++ b/encoding/mvt/README.md
@@ -52,3 +52,14 @@ data, err := layers.Marshal() // this data is NOT gzipped.
 // Sometimes MVT data is stored and transfered gzip compressed. In that case:
 data, err := layers.MarshalGzipped()
 ```
+
+### Feature IDs
+
+Since GeoJSON ids can be any number or string they won't necessarily map to vector tile uint64 ids.
+This is a common incompatibility between the two types.
+
+During marshaling the code tries to convert the geojson.Feature.ID to a positive integer, possibly parsing a string.
+If the number is negative, the id is omitted. If the number is a positive decimal the number is truncated.
+
+For unmarshaling the id will be converted into a float64 to be consistent with how
+the encoding/json package decodes numbers.


### PR DESCRIPTION
The encoding/mvt package converts geojson into mapbox vector tiles (mvt). The problem is [geojson](https://tools.ietf.org/html/rfc7946#section-3.2) allows ids of strings and numbers while [mvt](https://github.com/mapbox/vector-tile-spec/blob/master/1.0.1/vector_tile.proto#L30) only allows uint64 (positive numbers).  This is a common incompatibility between the two types.

For marshaling, the change is to try to convert the geojson.Feature.ID into an uint64. If it's a number type and positive, it converts to unit64. If it's a string it tries to decode.

Cavets:
* If the number is negative the feature ID will be omitted.
* If the number is a decimal, e.g. 123.45. the encode id will be the truncated, e.g. 123.

Unmarshaling code was also updated to decode ids into float64 to be consistent with what json does with numbers. That way if you have the same data in geojson or mvt the decoded types will be the same.

@jerluc