### PR TITLE
encoding/wkb: scanner to noop on nil data

### DIFF
--- a/encoding/wkb/scanner.go
+++ b/encoding/wkb/scanner.go
@@ -48,9 +48,17 @@ func Scanner(g interface{}) *GeometryScanner {
 // This could be into the orb geometry type pointer or, if nil,
 // the scanner.Geometry attribute.
 func (s *GeometryScanner) Scan(d interface{}) error {
+	if d == nil {
+		return nil
+	}
+
 	data, ok := d.([]byte)
 	if !ok {
 		return ErrUnsupportedDataType
+	}
+
+	if data == nil {
+		return nil
 	}
 
 	switch g := s.g.(type) {

--- a/encoding/wkb/scanner.go
+++ b/encoding/wkb/scanner.go
@@ -331,5 +331,9 @@ func Value(g orb.Geometry) driver.Valuer {
 }
 
 func (v value) Value() (driver.Value, error) {
-	return Marshal(v.v)
+	val, err := Marshal(v.v)
+	if val == nil {
+		return nil, err
+	}
+	return val, err
 }

--- a/encoding/wkb/scanner_test.go
+++ b/encoding/wkb/scanner_test.go
@@ -2,6 +2,7 @@ package wkb
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 
 	"github.com/paulmach/orb"
@@ -26,6 +27,10 @@ func TestScanNil(t *testing.T) {
 		if err != nil {
 			t.Errorf("should noop for nil data: %v", err)
 		}
+
+		if s.Valid {
+			t.Errorf("valid should be false for nil values")
+		}
 	})
 
 	t.Run("scan nil byte interface", func(t *testing.T) {
@@ -36,6 +41,10 @@ func TestScanNil(t *testing.T) {
 		err := s.Scan(b)
 		if err != nil {
 			t.Errorf("should noop for nil data: %v", err)
+		}
+
+		if s.Valid {
+			t.Errorf("valid should be false for nil values")
 		}
 	})
 }
@@ -71,6 +80,14 @@ func TestScanPoint(t *testing.T) {
 				t.Errorf("unequal data")
 				t.Log(p)
 				t.Log(tc.expected)
+			}
+
+			if p != s.Geometry {
+				t.Errorf("should set to scanner's geometry attribute")
+			}
+
+			if !s.Valid {
+				t.Errorf("should set valid to true")
 			}
 		})
 	}
@@ -113,6 +130,14 @@ func TestScanPoint_Errors(t *testing.T) {
 			if err != tc.err {
 				t.Errorf("incorrect error: %v != %v", err, tc.err)
 			}
+
+			if s.Geometry != nil {
+				t.Errorf("geometry should be nil on errors")
+			}
+
+			if s.Valid {
+				t.Errorf("valid should be false on errors")
+			}
 		})
 	}
 }
@@ -149,6 +174,14 @@ func TestScanMultiPoint(t *testing.T) {
 				t.Log(mp)
 				t.Log(tc.expected)
 			}
+
+			if !reflect.DeepEqual(mp, s.Geometry) {
+				t.Errorf("should set to scanner's geometry attribute")
+			}
+
+			if !s.Valid {
+				t.Errorf("should set valid to true")
+			}
 		})
 	}
 }
@@ -183,6 +216,14 @@ func TestScanMultiPoint_Errors(t *testing.T) {
 			err := s.Scan(tc.data)
 			if err != tc.err {
 				t.Errorf("incorrect error: %v != %v", err, tc.err)
+			}
+
+			if s.Geometry != nil {
+				t.Errorf("geometry should be nil on errors")
+			}
+
+			if s.Valid {
+				t.Errorf("valid should be false on errors")
 			}
 		})
 	}
@@ -220,6 +261,14 @@ func TestScanLineString(t *testing.T) {
 				t.Log(ls)
 				t.Log(tc.expected)
 			}
+
+			if !reflect.DeepEqual(ls, s.Geometry) {
+				t.Errorf("should set to scanner's geometry attribute")
+			}
+
+			if !s.Valid {
+				t.Errorf("should set valid to true")
+			}
 		})
 	}
 }
@@ -254,6 +303,14 @@ func TestScanLineString_Errors(t *testing.T) {
 			err := s.Scan(tc.data)
 			if err != tc.err {
 				t.Errorf("incorrect error: %v != %v", err, tc.err)
+			}
+
+			if s.Geometry != nil {
+				t.Errorf("geometry should be nil on errors")
+			}
+
+			if s.Valid {
+				t.Errorf("valid should be false on errors")
 			}
 		})
 	}
@@ -296,6 +353,14 @@ func TestScanMultiLineString(t *testing.T) {
 				t.Log(mls)
 				t.Log(tc.expected)
 			}
+
+			if !reflect.DeepEqual(mls, s.Geometry) {
+				t.Errorf("should set to scanner's geometry attribute")
+			}
+
+			if !s.Valid {
+				t.Errorf("should set valid to true")
+			}
 		})
 	}
 }
@@ -331,6 +396,14 @@ func TestScanMultiLineString_Errors(t *testing.T) {
 			if err != tc.err {
 				t.Errorf("incorrect error: %v != %v", err, tc.err)
 			}
+
+			if s.Geometry != nil {
+				t.Errorf("geometry should be nil on errors")
+			}
+
+			if s.Valid {
+				t.Errorf("valid should be false on errors")
+			}
 		})
 	}
 }
@@ -361,6 +434,14 @@ func TestScanRing(t *testing.T) {
 				t.Errorf("unequal data")
 				t.Log(r)
 				t.Log(tc.expected)
+			}
+
+			if !reflect.DeepEqual(r, s.Geometry) {
+				t.Errorf("should set to scanner's geometry attribute")
+			}
+
+			if !s.Valid {
+				t.Errorf("should set valid to true")
 			}
 		})
 	}
@@ -396,6 +477,14 @@ func TestScanRing_Errors(t *testing.T) {
 			err := s.Scan(tc.data)
 			if err != tc.err {
 				t.Errorf("incorrect error: %v != %v", err, tc.err)
+			}
+
+			if s.Geometry != nil {
+				t.Errorf("geometry should be nil on errors")
+			}
+
+			if s.Valid {
+				t.Errorf("valid should be false on errors")
 			}
 		})
 	}
@@ -433,6 +522,14 @@ func TestScanPolygon(t *testing.T) {
 				t.Log(p)
 				t.Log(tc.expected)
 			}
+
+			if !reflect.DeepEqual(p, s.Geometry) {
+				t.Errorf("should set to scanner's geometry attribute")
+			}
+
+			if !s.Valid {
+				t.Errorf("should set valid to true")
+			}
 		})
 	}
 }
@@ -467,6 +564,14 @@ func TestScanPolygon_Errors(t *testing.T) {
 			err := s.Scan(tc.data)
 			if err != tc.err {
 				t.Errorf("incorrect error: %v != %v", err, tc.err)
+			}
+
+			if s.Geometry != nil {
+				t.Errorf("geometry should be nil on errors")
+			}
+
+			if s.Valid {
+				t.Errorf("valid should be false on errors")
 			}
 		})
 	}
@@ -509,6 +614,14 @@ func TestScanMultiPolygon(t *testing.T) {
 				t.Log(mp)
 				t.Log(tc.expected)
 			}
+
+			if !reflect.DeepEqual(mp, s.Geometry) {
+				t.Errorf("should set to scanner's geometry attribute")
+			}
+
+			if !s.Valid {
+				t.Errorf("should set valid to true")
+			}
 		})
 	}
 }
@@ -544,6 +657,14 @@ func TestScanMultiPolygon_Errors(t *testing.T) {
 			if err != tc.err {
 				t.Errorf("incorrect error: %v != %v", err, tc.err)
 			}
+
+			if s.Geometry != nil {
+				t.Errorf("geometry should be nil on errors")
+			}
+
+			if s.Valid {
+				t.Errorf("valid should be false on errors")
+			}
 		})
 	}
 }
@@ -574,6 +695,14 @@ func TestScanCollection(t *testing.T) {
 				t.Errorf("unequal data")
 				t.Log(c)
 				t.Log(tc.expected)
+			}
+
+			if !reflect.DeepEqual(c, s.Geometry) {
+				t.Errorf("should set to scanner's geometry attribute")
+			}
+
+			if !s.Valid {
+				t.Errorf("should set valid to true")
 			}
 		})
 	}
@@ -609,6 +738,14 @@ func TestScanCollection_Errors(t *testing.T) {
 			err := s.Scan(tc.data)
 			if err != tc.err {
 				t.Errorf("incorrect error: %v != %v", err, tc.err)
+			}
+
+			if s.Geometry != nil {
+				t.Errorf("geometry should be nil on errors")
+			}
+
+			if s.Valid {
+				t.Errorf("valid should be false on errors")
 			}
 		})
 	}
@@ -681,6 +818,14 @@ func TestScanBound(t *testing.T) {
 				t.Log(b)
 				t.Log(tc.expected)
 			}
+
+			if !reflect.DeepEqual(b, s.Geometry) {
+				t.Errorf("should set to scanner's geometry attribute")
+			}
+
+			if !s.Valid {
+				t.Errorf("should set valid to true")
+			}
 		})
 	}
 }
@@ -710,6 +855,14 @@ func TestScanBound_Errors(t *testing.T) {
 			err := s.Scan(tc.data)
 			if err != tc.err {
 				t.Errorf("incorrect error: %v != %v", err, tc.err)
+			}
+
+			if s.Geometry != nil {
+				t.Errorf("geometry should be nil on errors")
+			}
+
+			if s.Valid {
+				t.Errorf("valid should be false on errors")
 			}
 		})
 	}

--- a/encoding/wkb/scanner_test.go
+++ b/encoding/wkb/scanner_test.go
@@ -869,14 +869,86 @@ func TestScanBound_Errors(t *testing.T) {
 }
 
 func TestValue(t *testing.T) {
-	val, err := Value(testPoint).Value()
-	if err != nil {
-		t.Errorf("value error: %v", err)
+	t.Run("marshalls geometry", func(t *testing.T) {
+		val, err := Value(testPoint).Value()
+		if err != nil {
+			t.Errorf("value error: %v", err)
+		}
+
+		if !bytes.Equal(val.([]byte), testPointData) {
+			t.Errorf("incorrect marshal")
+			t.Log(val)
+			t.Log(testPointData)
+		}
+	})
+
+	t.Run("nil value in should set nil value", func(t *testing.T) {
+		val, err := Value(nil).Value()
+		if err != nil {
+			t.Errorf("value error: %v", err)
+		}
+
+		if val != nil {
+			t.Errorf("should be nil value: %[1]T, %[1]v", val)
+		}
+	})
+}
+
+func TestValue_nil(t *testing.T) {
+	var (
+		mp    orb.MultiPoint
+		ls    orb.LineString
+		mls   orb.MultiLineString
+		r     orb.Ring
+		poly  orb.Polygon
+		mpoly orb.MultiPolygon
+		c     orb.Collection
+	)
+
+	cases := []struct {
+		name string
+		geom orb.Geometry
+	}{
+		{
+			name: "nil multi point",
+			geom: mp,
+		},
+		{
+			name: "nil line string",
+			geom: ls,
+		},
+		{
+			name: "nil multi line string",
+			geom: mls,
+		},
+		{
+			name: "nil ring",
+			geom: r,
+		},
+		{
+			name: "nil polygon",
+			geom: poly,
+		},
+		{
+			name: "nil multi polygon",
+			geom: mpoly,
+		},
+		{
+			name: "nil collection",
+			geom: c,
+		},
 	}
 
-	if !bytes.Equal(val.([]byte), testPointData) {
-		t.Errorf("incorrect marshal")
-		t.Log(val)
-		t.Log(testPointData)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			val, err := Value(tc.geom).Value()
+			if err != nil {
+				t.Errorf("value error: %v", err)
+			}
+
+			if val != nil {
+				t.Errorf("should be nil value: %[1]T, %[1]v", val)
+			}
+		})
 	}
 }

--- a/encoding/wkb/scanner_test.go
+++ b/encoding/wkb/scanner_test.go
@@ -17,6 +17,27 @@ func TestScanNil(t *testing.T) {
 	if !orb.Equal(s.Geometry, testPoint) {
 		t.Errorf("incorrect geometry: %v != %v", s.Geometry, testPoint)
 	}
+
+	t.Run("scan nil data", func(t *testing.T) {
+		var p orb.Point
+		s := Scanner(&p)
+
+		err := s.Scan(nil)
+		if err != nil {
+			t.Errorf("should noop for nil data: %v", err)
+		}
+	})
+
+	t.Run("scan nil byte interface", func(t *testing.T) {
+		var p orb.Point
+		s := Scanner(&p)
+
+		var b []byte
+		err := s.Scan(b)
+		if err != nil {
+			t.Errorf("should noop for nil data: %v", err)
+		}
+	})
 }
 
 func TestScanPoint(t *testing.T) {

--- a/encoding/wkb/wkb.go
+++ b/encoding/wkb/wkb.go
@@ -66,6 +66,10 @@ func Marshal(geom orb.Geometry, byteOrder ...binary.ByteOrder) ([]byte, error) {
 		return nil, err
 	}
 
+	if buf.Len() == 0 {
+		return nil, nil
+	}
+
 	return buf.Bytes(), nil
 }
 
@@ -89,9 +93,38 @@ func (e *Encoder) Encode(geom orb.Geometry) error {
 		return nil
 	}
 
-	// deal with types that are not supported by wkb
 	switch g := geom.(type) {
+	// nil values should not write any data. Empty sizes will still
+	// write and empty version of that type.
+	case orb.MultiPoint:
+		if g == nil {
+			return nil
+		}
+	case orb.LineString:
+		if g == nil {
+			return nil
+		}
+	case orb.MultiLineString:
+		if g == nil {
+			return nil
+		}
+	case orb.Polygon:
+		if g == nil {
+			return nil
+		}
+	case orb.MultiPolygon:
+		if g == nil {
+			return nil
+		}
+	case orb.Collection:
+		if g == nil {
+			return nil
+		}
+	// deal with types that are not supported by wkb
 	case orb.Ring:
+		if g == nil {
+			return nil
+		}
 		geom = orb.Polygon{g}
 	case orb.Bound:
 		geom = g.ToPolygon()
@@ -248,6 +281,6 @@ func geomLength(geom orb.Geometry) int {
 
 		return 9 + sum
 	}
-	return 0
 
+	return 0
 }


### PR DESCRIPTION
see https://github.com/paulmach/orb/issues/21

when the data is nil or empty do a noop on vs. returning an error. Also the new `.Valid` attribute will be false in these cases.