### PR TITLE
encoding/wkb: Only limit allocation not reading

### DIFF
--- a/encoding/wkb/collection.go
+++ b/encoding/wkb/collection.go
@@ -13,12 +13,13 @@ func readCollection(r io.Reader, bom binary.ByteOrder) (orb.Collection, error) {
 		return nil, err
 	}
 
-	if num > maxMultiAlloc {
+	alloc := num
+	if alloc > maxMultiAlloc {
 		// invalid data can come in here and allocate tons of memory.
-		num = maxMultiAlloc
+		alloc = maxMultiAlloc
 	}
+	result := make(orb.Collection, 0, alloc)
 
-	result := make(orb.Collection, 0, num)
 	for i := 0; i < int(num); i++ {
 		geom, err := NewDecoder(r).Decode()
 		if err != nil {

--- a/encoding/wkb/collection_test.go
+++ b/encoding/wkb/collection_test.go
@@ -30,6 +30,11 @@ var (
 )
 
 func TestCollection(t *testing.T) {
+	large := orb.Collection{}
+	for i := 0; i < maxMultiAlloc+100; i++ {
+		large = append(large, orb.Point{float64(i), float64(-i)})
+	}
+
 	cases := []struct {
 		name     string
 		data     []byte
@@ -39,6 +44,11 @@ func TestCollection(t *testing.T) {
 			name:     "collection",
 			data:     testCollectionData,
 			expected: testCollection,
+		},
+		{
+			name:     "large",
+			data:     MustMarshal(large),
+			expected: large,
 		},
 	}
 

--- a/encoding/wkb/line_string.go
+++ b/encoding/wkb/line_string.go
@@ -15,12 +15,13 @@ func readLineString(r io.Reader, bom binary.ByteOrder) (orb.LineString, error) {
 		return nil, err
 	}
 
-	if num > maxPointsAlloc {
+	alloc := num
+	if alloc > maxPointsAlloc {
 		// invalid data can come in here and allocate tons of memory.
-		num = maxPointsAlloc
+		alloc = maxPointsAlloc
 	}
+	result := make(orb.LineString, 0, alloc)
 
-	result := make(orb.LineString, 0, num)
 	for i := 0; i < int(num); i++ {
 		p, err := readPoint(r, bom)
 		if err != nil {

--- a/encoding/wkb/line_string.go
+++ b/encoding/wkb/line_string.go
@@ -60,12 +60,13 @@ func readMultiLineString(r io.Reader, bom binary.ByteOrder) (orb.MultiLineString
 		return nil, err
 	}
 
-	if num > maxMultiAlloc {
+	alloc := num
+	if alloc > maxMultiAlloc {
 		// invalid data can come in here and allocate tons of memory.
-		num = maxMultiAlloc
+		alloc = maxMultiAlloc
 	}
+	result := make(orb.MultiLineString, 0, alloc)
 
-	result := make(orb.MultiLineString, 0, num)
 	for i := 0; i < int(num); i++ {
 		byteOrder, typ, err := readByteOrderType(r)
 		if err != nil {

--- a/encoding/wkb/line_string_test.go
+++ b/encoding/wkb/line_string_test.go
@@ -94,6 +94,11 @@ var (
 )
 
 func TestMultiLineString(t *testing.T) {
+	large := orb.MultiLineString{}
+	for i := 0; i < maxMultiAlloc+100; i++ {
+		large = append(large, orb.LineString{})
+	}
+
 	cases := []struct {
 		name     string
 		data     []byte
@@ -108,6 +113,11 @@ func TestMultiLineString(t *testing.T) {
 			name:     "single multi line string",
 			data:     testMultiLineStringSingleData,
 			expected: testMultiLineStringSingle,
+		},
+		{
+			name:     "large",
+			data:     MustMarshal(large),
+			expected: large,
 		},
 	}
 

--- a/encoding/wkb/line_string_test.go
+++ b/encoding/wkb/line_string_test.go
@@ -16,6 +16,11 @@ var (
 )
 
 func TestLineString(t *testing.T) {
+	large := orb.LineString{}
+	for i := 0; i < maxPointsAlloc+100; i++ {
+		large = append(large, orb.Point{float64(i), float64(-i)})
+	}
+
 	cases := []struct {
 		name     string
 		data     []byte
@@ -25,6 +30,11 @@ func TestLineString(t *testing.T) {
 			name:     "line string",
 			data:     testLineStringData,
 			expected: testLineString,
+		},
+		{
+			name:     "large line string",
+			data:     MustMarshal(large),
+			expected: large,
 		},
 	}
 

--- a/encoding/wkb/point.go
+++ b/encoding/wkb/point.go
@@ -42,12 +42,13 @@ func readMultiPoint(r io.Reader, bom binary.ByteOrder) (orb.MultiPoint, error) {
 		return nil, err
 	}
 
-	if num > maxPointsAlloc {
+	alloc := num
+	if alloc > maxPointsAlloc {
 		// invalid data can come in here and allocate tons of memory.
-		num = maxPointsAlloc
+		alloc = maxPointsAlloc
 	}
+	result := make(orb.MultiPoint, 0, alloc)
 
-	result := make(orb.MultiPoint, 0, num)
 	for i := 0; i < int(num); i++ {
 		byteOrder, typ, err := readByteOrderType(r)
 		if err != nil {

--- a/encoding/wkb/point_test.go
+++ b/encoding/wkb/point_test.go
@@ -86,6 +86,11 @@ var (
 )
 
 func TestMultiPoint(t *testing.T) {
+	large := orb.MultiPoint{}
+	for i := 0; i < maxPointsAlloc+100; i++ {
+		large = append(large, orb.Point{float64(i), float64(-i)})
+	}
+
 	cases := []struct {
 		name     string
 		data     []byte
@@ -100,6 +105,11 @@ func TestMultiPoint(t *testing.T) {
 			name:     "single multi point",
 			data:     testMultiPointSingleData,
 			expected: testMultiPointSingle,
+		},
+		{
+			name:     "large multi point",
+			data:     MustMarshal(large),
+			expected: large,
 		},
 	}
 

--- a/encoding/wkb/polygon.go
+++ b/encoding/wkb/polygon.go
@@ -15,12 +15,13 @@ func readPolygon(r io.Reader, bom binary.ByteOrder) (orb.Polygon, error) {
 		return nil, err
 	}
 
-	if num > maxMultiAlloc {
+	alloc := num
+	if alloc > maxMultiAlloc {
 		// invalid data can come in here and allocate tons of memory.
-		num = maxMultiAlloc
+		alloc = maxMultiAlloc
 	}
+	result := make(orb.Polygon, 0, alloc)
 
-	result := make(orb.Polygon, 0, num)
 	for i := 0; i < int(num); i++ {
 		ls, err := readLineString(r, bom)
 		if err != nil {
@@ -64,12 +65,13 @@ func readMultiPolygon(r io.Reader, bom binary.ByteOrder) (orb.MultiPolygon, erro
 		return nil, err
 	}
 
-	if num > maxMultiAlloc {
+	alloc := num
+	if alloc > maxMultiAlloc {
 		// invalid data can come in here and allocate tons of memory.
-		num = maxMultiAlloc
+		alloc = maxMultiAlloc
 	}
+	result := make(orb.MultiPolygon, 0, alloc)
 
-	result := make(orb.MultiPolygon, 0, num)
 	for i := 0; i < int(num); i++ {
 		byteOrder, typ, err := readByteOrderType(r)
 		if err != nil {

--- a/encoding/wkb/polygon_test.go
+++ b/encoding/wkb/polygon_test.go
@@ -29,6 +29,11 @@ var (
 )
 
 func TestPolygon(t *testing.T) {
+	large := orb.Polygon{}
+	for i := 0; i < maxMultiAlloc+100; i++ {
+		large = append(large, orb.Ring{})
+	}
+
 	cases := []struct {
 		name     string
 		data     []byte
@@ -38,6 +43,11 @@ func TestPolygon(t *testing.T) {
 			name:     "polygon",
 			data:     testPolygonData,
 			expected: testPolygon,
+		},
+		{
+			name:     "large",
+			data:     MustMarshal(large),
+			expected: large,
 		},
 		{
 			name: "two ring polygon",
@@ -155,6 +165,11 @@ var (
 )
 
 func TestMultiPolygon(t *testing.T) {
+	large := orb.MultiPolygon{}
+	for i := 0; i < maxMultiAlloc+100; i++ {
+		large = append(large, orb.Polygon{})
+	}
+
 	cases := []struct {
 		name     string
 		data     []byte
@@ -169,6 +184,11 @@ func TestMultiPolygon(t *testing.T) {
 			name:     "single multi polygon",
 			data:     testMultiPolygonSingleData,
 			expected: testMultiPolygonSingle,
+		},
+		{
+			name:     "large",
+			data:     MustMarshal(large),
+			expected: large,
 		},
 		{
 			name: "three polygons",

--- a/encoding/wkb/wkb.go
+++ b/encoding/wkb/wkb.go
@@ -23,7 +23,7 @@ const (
 const (
 	// limits so that bad data can't come in allocate way tons of memory.
 	// Well formed data with less elements will allocate the correct amount just fine.
-	maxPointsAlloc = 5000
+	maxPointsAlloc = 10000
 	maxMultiAlloc  = 100
 )
 


### PR DESCRIPTION
Fixes https://github.com/paulmach/orb/issues/26

Intention is to preallocate the memory needed by the item. This is great for wellformed input. However, bad data could have a big number as the first few bytes causing a large allocation to be requested. So we want to max out this preallocation to prevent that. 

In the malformed case you'd probably get a io.EOF type error.

The original code limited the allocation and the number read. Good, but very big, data was not read in completely.  Ooops....