### PR TITLE
Adds IntermediatePoint function to orb/geo.

### DIFF
--- a/geo/distance.go
+++ b/geo/distance.go
@@ -69,3 +69,31 @@ func Midpoint(p, p2 orb.Point) orb.Point {
 
 	return r
 }
+
+// IntermediatePoint returns a point along the great circle from a point (p) toward
+// a destination (p2). f is a number from 0 to 1 specifying the amount to proceed
+// along that path (0 = source, 1 = destination).
+func IntermediatePoint(p, p2 orb.Point, f float64) orb.Point {
+	// This is based on the intermediatePointTo function from:
+	// http://www.movable-type.co.uk/scripts/latlong.html
+	p1XRad, p1YRad := deg2rad(p.X()), deg2rad(p.Y())
+	p2XRad, p2YRad := deg2rad(p2.X()), deg2rad(p2.Y())
+
+	dX := p2XRad - p1XRad
+	dY := p2YRad - p1YRad
+
+	a := math.Sin(dY/2)*math.Sin(dY/2) + math.Cos(p1YRad)*math.Cos(p2YRad)*math.Sin(dX/2)*math.Sin(dX/2)
+	d := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+
+	A := math.Sin((1-f)*d) / math.Sin(d)
+	B := math.Sin(f*d) / math.Sin(d)
+
+	x := A*math.Cos(p1YRad)*math.Cos(p1XRad) + B*math.Cos(p2YRad)*math.Cos(p2XRad)
+	y := A*math.Cos(p1YRad)*math.Sin(p1XRad) + B*math.Cos(p2YRad)*math.Sin(p2XRad)
+	z := A*math.Sin(p1YRad) + B*math.Sin(p2YRad)
+
+	y3 := math.Atan2(z, math.Sqrt(x*x+y*y))
+	x3 := math.Atan2(y, x)
+
+	return orb.Point{rad2deg(x3), rad2deg(y3)}
+}

--- a/geo/distance_test.go
+++ b/geo/distance_test.go
@@ -89,3 +89,23 @@ func TestMidpoint(t *testing.T) {
 		t.Errorf("expected %v, got %v", answer, m)
 	}
 }
+
+func TestIntermediatePoint(t *testing.T) {
+	p1 := orb.Point{-77.035382, 38.898269}
+	p2 := orb.Point{-77.011250, 38.889789}
+
+	data := [3][3]float64{
+		{0.25, -77.02934845975295, 38.896149465676906},
+		{0.50, -77.02331527966795, 38.894029620874510},
+		{0.75, -77.01728245974898, 38.891909465634875},
+	}
+	for _, d := range data {
+		f := d[0]
+		answer := orb.Point{d[1], d[2]}
+
+		p := IntermediatePoint(p1, p2, f)
+		if d := Distance(p, answer); d > 1 {
+			t.Errorf("expected %v for f = %v; got %v", answer, f, p)
+		}
+	}
+}


### PR DESCRIPTION
`orb/geo`currently provides a `Midpoint` function for computing the midpoint along the great circle from one point to another. I need one that calculates intermediate points, given some fraction `f in [0, 1]` where `f = 0` corresponds to the source point and `f = 1` corresponds to the destination point.

I think it makes more sense for this to live in `orb/geo` than my own internal libraries. Thoughts?