### PR TITLE
Adding "when" field support for temporal GeoJSON according to geojson/geojson-ld

### DIFF
--- a/geojson/feature.go
+++ b/geojson/feature.go
@@ -14,6 +14,7 @@ type Feature struct {
 	BBox       BBox         `json:"bbox,omitempty"`
 	Geometry   orb.Geometry `json:"geometry"`
 	Properties Properties   `json:"properties"`
+	When       *When         `json:"when,omitempty"`
 }
 
 // NewFeature creates and initializes a GeoJSON feature given the required attributes.
@@ -44,6 +45,7 @@ func (f Feature) MarshalJSON() ([]byte, error) {
 		Properties: f.Properties,
 		BBox:       f.BBox,
 		Geometry:   NewGeometry(f.Geometry),
+		When:       f.When,
 	}
 
 	if len(jf.Properties) == 0 {
@@ -84,6 +86,7 @@ func (f *Feature) UnmarshalJSON(data []byte) error {
 		Properties: jf.Properties,
 		BBox:       jf.BBox,
 		Geometry:   jf.Geometry.Coordinates,
+		When:       jf.When,
 	}
 
 	return nil
@@ -93,6 +96,7 @@ type jsonFeature struct {
 	ID         interface{} `json:"id,omitempty"`
 	Type       string      `json:"type"`
 	BBox       BBox        `json:"bbox,omitempty"`
-	Geometry   *Geometry   `json:"geometry"`
+	Geometry   *Geometry   `json:"geometry,omitempty"`
 	Properties Properties  `json:"properties"`
+	When       *When       `json:"when,omitempty"`
 }

--- a/geojson/feature_test.go
+++ b/geojson/feature_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/paulmach/orb"
 )
@@ -89,6 +90,23 @@ func TestFeatureMarshal(t *testing.T) {
 	}
 }
 
+func TestFeatureWhenMarshal(t *testing.T) {
+	f := NewFeature(orb.Point{1, 2})
+	tt := time.Now()
+	f.When = &When{"Instant", &tt}
+	blob, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("should marshal to json just fine but got %v", err)
+	}
+
+	if !bytes.Contains(blob, []byte(`"when":`)) {
+		t.Errorf("json should contain 'when' node")
+	}
+	if !bytes.Contains(blob, []byte(`"@type":"Instant"`)) {
+		t.Errorf("json should have 'when.@type' attribute")
+	}
+}
+
 func TestFeatureMarshalValue(t *testing.T) {
 	f := NewFeature(orb.Point{1, 2})
 	blob, err := json.Marshal(*f)
@@ -106,7 +124,8 @@ func TestUnmarshalFeature(t *testing.T) {
 	rawJSON := `
 	  { "type": "Feature",
 	    "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
-	    "properties": {"prop0": "value0"}
+		"properties": {"prop0": "value0"},
+		"when": {"@type": "Instant", "datetime": "2019-01-02T15:04:05Z"}
 	  }`
 
 	f, err := UnmarshalFeature([]byte(rawJSON))
@@ -151,7 +170,8 @@ func TestUnmarshalFeature_BBox(t *testing.T) {
 	  { "type": "Feature",
 	    "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
 		"bbox": [1,2,3,4],
-	    "properties": {"prop0": "value0"}
+	    "properties": {"prop0": "value0"},
+		"when": {"@type": "Instant", "datetime": "2009-07-12T05:03:01Z"}
 	  }`
 
 	f, err := UnmarshalFeature([]byte(rawJSON))

--- a/geojson/when.go
+++ b/geojson/when.go
@@ -2,7 +2,8 @@ package geojson
 
 import "time"
 
-// When is a datetime info bound to Features objects
+// "When" is a datetime info bound to Features objects
+// Geojson spec at https://github.com/geojson/geojson-ld
 
 type When struct {
 	Type         string           `json:"@type,omitempty"`
@@ -20,3 +21,4 @@ func (w *When) Valid() bool {
 	}
 	return false
 }
+

--- a/geojson/when.go
+++ b/geojson/when.go
@@ -1,0 +1,22 @@
+package geojson
+
+import "time"
+
+// When is a datetime info bound to Features objects
+
+type When struct {
+	Type         string           `json:"@type,omitempty"`
+	Datetime     *time.Time        `json:"datetime,omitempty"`
+}
+
+// NewWhen creates a when clause
+func NewWhen(Type string, Datetime *time.Time) When {
+	return When{Type, Datetime}
+}
+
+func (w *When) Valid() bool {
+	if w.Type == "Instant" || w.Type=="Interval" {
+		return w.Datetime.Year() != 1
+	}
+	return false
+}

--- a/geojson/when_test.go
+++ b/geojson/when_test.go
@@ -1,0 +1,30 @@
+package geojson
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWhen1(t *testing.T) {
+	t1, err := time.Parse(time.RFC3339, "2012-11-01T22:08:41+00:00")
+	if err != nil {
+		t.Errorf("Error instantiating date for test. err=%s", err)
+		return
+	}
+	when1 := When{"Instant", &t1}
+	if !when1.Valid() {
+		t.Errorf("When is invalid. when=%v", when1)
+	}
+}
+
+func TestWhen2(t *testing.T) {
+	t1, err := time.Parse(time.RFC3339, "2002-01-01T22:08:41+00:00")
+	if err != nil {
+		t.Errorf("Error instantiating date for test. err=%s", err)
+		return
+	}
+	when1 := When{"StrangeType", &t1}
+	if when1.Valid() {
+		t.Errorf("When should be marked invalid. when=%v", when1)
+	}
+}


### PR DESCRIPTION
There is an extension in geojson for temporal data bound to features.

See #31 for more details on the proposal.

#close #31 