### PR TITLE
Command line tool: vt2geojson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ cmd/__debug_bin
 cmd/*/__debug_bin
 cmd/vt2geojson/vt2geojson
 
-
+# vscode
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ cmd/vt2geojson/vt2geojson
 
 # vscode
 .vscode/
+
+# mac
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+
+# binaries
+cmd/__debug_bin
+cmd/*/__debug_bin
+cmd/vt2geojson/vt2geojson
+
+

--- a/cmd/vt2geojson/README.md
+++ b/cmd/vt2geojson/README.md
@@ -1,0 +1,52 @@
+# vt2geojson
+Dump vector tiles to GeoJSON.     
+Similar with [mapbox/vt2geojson](https://github.com/mapbox/vt2geojson), but implemented by `Golang` and based on [paulmach/orb](github.com/paulmach/orb/) library.     
+
+## Usage
+
+```bash
+$ cd cmd/vt2geojson
+$ go build 
+```
+
+- CLI helper
+```bash
+./vt2geojson -h
+Usage of ./vt2geojson:
+  -layer string
+    	Include only the specified layer of the Mapbox Vector Tile.
+  -mvt string
+    	Mapbox Vector Tile file path or URL, e.g. 'xxx.mvt' or 'xxx.vector.pbf' or 'https://api.mapbox.com/v4/mapbox.mapbox-streets-v6/9/150/194.mvt?access_token=YOUR_MAPBOX_ACCESS_TOKEN'.
+  -summary
+    	Print layers summary only.
+  -x uint
+    	Tile x coordinate
+  -y uint
+    	Tile x coordinate
+  -z uint
+    	Tile zoom level.
+```
+
+- example
+```bash
+$ # print mvt layers summary 
+$ ./vt2geojson -mvt https://api.mapbox.com/v4/mapbox.mapbox-streets-v6/9/150/194.mvt?access_token=YOUR_MAPBOX_ACCESS_TOKEN -summary
+layer landuse, version 2, extent 4096, features 202
+layer waterway, version 2, extent 4096, features 24
+layer water, version 2, extent 4096, features 27
+layer aeroway, version 2, extent 4096, features 5
+layer landuse_overlay, version 2, extent 4096, features 38
+layer road, version 2, extent 4096, features 787
+layer admin, version 2, extent 4096, features 2
+layer state_label, version 2, extent 4096, features 1
+layer place_label, version 2, extent 4096, features 64
+layer poi_label, version 2, extent 4096, features 17
+layer road_label, version 2, extent 4096, features 11
+$ 
+$ # convert to geojson and dump to file
+$ ./vt2geojson -x 150 -y 194 -z 9 -mvt https://api.mapbox.com/v4/mapbox.mapbox-streets-v6/9/150/194.mvt?access_token=YOUR_MAPBOX_ACCESS_TOKEN >geojson.json
+$ ### if by mapbox/vt2geojson, the command is: 
+$ ###   vt2geojson -x 150 -y 194 -z 9 https://api.mapbox.com/v4/mapbox.mapbox-streets-v6/9/150/194.mvt?access_token=YOUR_MAPBOX_ACCESS_TOKEN >geojson.json
+
+
+```

--- a/cmd/vt2geojson/README.md
+++ b/cmd/vt2geojson/README.md
@@ -2,17 +2,21 @@
 Dump vector tiles to GeoJSON.     
 Similar with [mapbox/vt2geojson](https://github.com/mapbox/vt2geojson), but implemented by `Golang` and based on [paulmach/orb](github.com/paulmach/orb/) library.     
 
-## Usage
-
+## Build
 ```bash
 $ cd cmd/vt2geojson
 $ go build 
 ```
 
+## Usage
+
+
 - CLI helper
 ```bash
 ./vt2geojson -h
 Usage of ./vt2geojson:
+  -gzipped
+    	Whether uncompress the '.mvt' by gzip or not. '.mvt' comes from mapbox server is always gzipped, whatever with the 'Accept-Encoding: gzip' or not. (default true)
   -layer string
     	Include only the specified layer of the Mapbox Vector Tile.
   -mvt string
@@ -20,11 +24,11 @@ Usage of ./vt2geojson:
   -summary
     	Print layers summary only.
   -x uint
-    	Tile x coordinate
+    	Tile x coordinate (normally inferred from the URL, e.g. 'z/x/y.mvt' or 'z/x/y.vector.pbf')
   -y uint
-    	Tile x coordinate
+    	Tile x coordinate (normally inferred from the URL, e.g. 'z/x/y.mvt' or 'z/x/y.vector.pbf')
   -z uint
-    	Tile zoom level.
+    	Tile zoom level (normally inferred from the URL, e.g. 'z/x/y.mvt' or 'z/x/y.vector.pbf')
 ```
 
 - example
@@ -44,9 +48,9 @@ layer poi_label, version 2, extent 4096, features 17
 layer road_label, version 2, extent 4096, features 11
 $ 
 $ # convert to geojson and dump to file
-$ ./vt2geojson -x 150 -y 194 -z 9 -mvt https://api.mapbox.com/v4/mapbox.mapbox-streets-v6/9/150/194.mvt?access_token=YOUR_MAPBOX_ACCESS_TOKEN >geojson.json
+$ ./vt2geojson -mvt https://api.mapbox.com/v4/mapbox.mapbox-streets-v6/9/150/194.mvt?access_token=YOUR_MAPBOX_ACCESS_TOKEN >geojson.json
 $ ### if by mapbox/vt2geojson, the command is: 
-$ ###   vt2geojson -x 150 -y 194 -z 9 https://api.mapbox.com/v4/mapbox.mapbox-streets-v6/9/150/194.mvt?access_token=YOUR_MAPBOX_ACCESS_TOKEN >geojson.json
+$ ###   vt2geojson https://api.mapbox.com/v4/mapbox.mapbox-streets-v6/9/150/194.mvt?access_token=YOUR_MAPBOX_ACCESS_TOKEN >geojson.json
 
 
 ```

--- a/cmd/vt2geojson/flags.go
+++ b/cmd/vt2geojson/flags.go
@@ -15,7 +15,7 @@ func init() {
 	flag.StringVar(&flags.mvtSource, "mvt", "", "Mapbox Vector Tile file path or URL, e.g. 'xxx.mvt' or 'xxx.vector.pbf' or 'https://api.mapbox.com/v4/mapbox.mapbox-streets-v6/9/150/194.mvt?access_token=YOUR_MAPBOX_ACCESS_TOKEN'.")
 	flag.StringVar(&flags.layer, "layer", "", "Include only the specified layer of the Mapbox Vector Tile.")
 	flag.BoolVar(&flags.summary, "summary", false, "Print layers summary only.")
-	flag.UintVar(&flags.x, "x", 150, "tile x coordinate")
-	flag.UintVar(&flags.y, "y", 194, "tile x coordinate")
-	flag.UintVar(&flags.z, "z", 9, "tile z coordinate, i.e. zoom level.")
+	flag.UintVar(&flags.x, "x", 0, "Tile x coordinate")
+	flag.UintVar(&flags.y, "y", 0, "Tile x coordinate")
+	flag.UintVar(&flags.z, "z", 0, "Tile zoom level.")
 }

--- a/cmd/vt2geojson/flags.go
+++ b/cmd/vt2geojson/flags.go
@@ -3,11 +3,11 @@ package main
 import "flag"
 
 var flags struct {
-	mvtFile string
-	layer   string
+	mvtSource string
+	layer     string
 }
 
 func init() {
-	flag.StringVar(&flags.mvtFile, "mvt", "", "Mapbox Vector Tile file path, e.g. 'xxx.mvt' or 'xxx.vector.pbf'.")
+	flag.StringVar(&flags.mvtSource, "mvt", "", "Mapbox Vector Tile file path or URL, e.g. 'xxx.mvt' or 'xxx.vector.pbf' or 'https://api.mapbox.com/v4/mapbox.mapbox-streets-v6/9/150/194.mvt?access_token=YOUR_MAPBOX_ACCESS_TOKEN'.")
 	flag.StringVar(&flags.layer, "layer", "", "Include only the specified layer of the Mapbox Vector Tile.")
 }

--- a/cmd/vt2geojson/flags.go
+++ b/cmd/vt2geojson/flags.go
@@ -5,9 +5,17 @@ import "flag"
 var flags struct {
 	mvtSource string
 	layer     string
+	summary   bool
+	x         uint
+	y         uint
+	z         uint
 }
 
 func init() {
 	flag.StringVar(&flags.mvtSource, "mvt", "", "Mapbox Vector Tile file path or URL, e.g. 'xxx.mvt' or 'xxx.vector.pbf' or 'https://api.mapbox.com/v4/mapbox.mapbox-streets-v6/9/150/194.mvt?access_token=YOUR_MAPBOX_ACCESS_TOKEN'.")
 	flag.StringVar(&flags.layer, "layer", "", "Include only the specified layer of the Mapbox Vector Tile.")
+	flag.BoolVar(&flags.summary, "summary", false, "Print layers summary only.")
+	flag.UintVar(&flags.x, "x", 150, "tile x coordinate")
+	flag.UintVar(&flags.y, "y", 194, "tile x coordinate")
+	flag.UintVar(&flags.z, "z", 9, "tile z coordinate, i.e. zoom level.")
 }

--- a/cmd/vt2geojson/flags.go
+++ b/cmd/vt2geojson/flags.go
@@ -16,8 +16,8 @@ func init() {
 	flag.StringVar(&flags.mvtSource, "mvt", "", "Mapbox Vector Tile file path or URL, e.g. 'xxx.mvt' or 'xxx.vector.pbf' or 'https://api.mapbox.com/v4/mapbox.mapbox-streets-v6/9/150/194.mvt?access_token=YOUR_MAPBOX_ACCESS_TOKEN'.")
 	flag.StringVar(&flags.layer, "layer", "", "Include only the specified layer of the Mapbox Vector Tile.")
 	flag.BoolVar(&flags.summary, "summary", false, "Print layers summary only.")
-	flag.UintVar(&flags.x, "x", 0, "Tile x coordinate")
-	flag.UintVar(&flags.y, "y", 0, "Tile x coordinate")
-	flag.UintVar(&flags.z, "z", 0, "Tile zoom level.")
+	flag.UintVar(&flags.x, "x", 0, "Tile x coordinate (normally inferred from the URL, e.g. 'z/x/y.mvt' or 'z/x/y.vector.pbf')")
+	flag.UintVar(&flags.y, "y", 0, "Tile x coordinate (normally inferred from the URL, e.g. 'z/x/y.mvt' or 'z/x/y.vector.pbf')")
+	flag.UintVar(&flags.z, "z", 0, "Tile zoom level (normally inferred from the URL, e.g. 'z/x/y.mvt' or 'z/x/y.vector.pbf')")
 	flag.BoolVar(&flags.gzipped, "gzipped", true, "Whether uncompress the '.mvt' by gzip or not. '.mvt' comes from mapbox server is always gzipped, whatever with the 'Accept-Encoding: gzip' or not.")
 }

--- a/cmd/vt2geojson/flags.go
+++ b/cmd/vt2geojson/flags.go
@@ -1,0 +1,11 @@
+package main
+
+import "flag"
+
+var flags struct {
+	mvtFile string
+}
+
+func init() {
+	flag.StringVar(&flags.mvtFile, "f", "", "Mapbox Vector Tile file path, e.g. 'xxx.mvt' or 'xxx.vector.pbf'.")
+}

--- a/cmd/vt2geojson/flags.go
+++ b/cmd/vt2geojson/flags.go
@@ -9,6 +9,7 @@ var flags struct {
 	x         uint
 	y         uint
 	z         uint
+	gzipped   bool
 }
 
 func init() {
@@ -18,4 +19,5 @@ func init() {
 	flag.UintVar(&flags.x, "x", 0, "Tile x coordinate")
 	flag.UintVar(&flags.y, "y", 0, "Tile x coordinate")
 	flag.UintVar(&flags.z, "z", 0, "Tile zoom level.")
+	flag.BoolVar(&flags.gzipped, "gzipped", true, "Whether uncompress the '.mvt' by gzip or not. '.mvt' comes from mapbox server is always gzipped, whatever with the 'Accept-Encoding: gzip' or not.")
 }

--- a/cmd/vt2geojson/flags.go
+++ b/cmd/vt2geojson/flags.go
@@ -4,8 +4,10 @@ import "flag"
 
 var flags struct {
 	mvtFile string
+	layer   string
 }
 
 func init() {
-	flag.StringVar(&flags.mvtFile, "f", "", "Mapbox Vector Tile file path, e.g. 'xxx.mvt' or 'xxx.vector.pbf'.")
+	flag.StringVar(&flags.mvtFile, "mvt", "", "Mapbox Vector Tile file path, e.g. 'xxx.mvt' or 'xxx.vector.pbf'.")
+	flag.StringVar(&flags.layer, "layer", "", "Include only the specified layer of the Mapbox Vector Tile.")
 }

--- a/cmd/vt2geojson/main.go
+++ b/cmd/vt2geojson/main.go
@@ -2,15 +2,35 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
 
-	"github.com/golang/glog"
+	"github.com/paulmach/orb/encoding/mvt"
 )
 
 func main() {
 	flag.Parse()
-	defer glog.Flush()
 
 	if len(flags.mvtFile) > 0 {
 		//TODO: parse mvt file to geojson
+
+		content, err := ioutil.ReadFile(flags.mvtFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		layers, err := mvt.Unmarshal(content)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if len(flags.layer) == 0 {
+			for _, l := range layers {
+				fmt.Printf("layer %s, version %d, extent %d, features %d\n", l.Name, l.Version, l.Extent, len(l.Features))
+			}
+			return
+		}
+		//fmt.Print(layers)
 	}
 }

--- a/cmd/vt2geojson/main.go
+++ b/cmd/vt2geojson/main.go
@@ -43,10 +43,8 @@ func main() {
 	flag.Parse()
 
 	if len(flags.mvtSource) == 0 {
-		log.Fatalf("Please specify the mvt source by '-mvt'")
+		log.Fatalf("Please specify the mvt file or URI by '-mvt'")
 	}
-
-	//TODO: parse mvt contents to geojson
 
 	content, err := readMVTContent(flags.mvtSource)
 	if err != nil {

--- a/cmd/vt2geojson/main.go
+++ b/cmd/vt2geojson/main.go
@@ -3,52 +3,11 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
-	"net/http"
-	"strings"
 
 	"github.com/paulmach/orb/geojson"
 	"github.com/paulmach/orb/maptile"
-
-	"github.com/paulmach/orb/encoding/mvt"
 )
-
-func loadMVT(mvtSource string) ([]byte, error) {
-
-	if strings.Index(mvtSource, "http") >= 0 { // download from URL
-		tr := &http.Transport{
-			DisableCompression: true, // disable the silently decompression
-		}
-		client := &http.Client{Transport: tr}
-		resp, err := client.Get(mvtSource)
-		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close()
-
-		content, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-
-		return content, nil
-	}
-
-	// otherwise read from file
-	content, err := ioutil.ReadFile(mvtSource)
-	if err != nil {
-		return nil, err
-	}
-	return content, nil
-}
-
-func unmarshalMVT(mvtContent []byte, gzipped bool) (mvt.Layers, error) {
-	if gzipped {
-		return mvt.UnmarshalGzipped(mvtContent)
-	}
-	return mvt.Unmarshal(mvtContent)
-}
 
 func main() {
 	flag.Parse()
@@ -68,9 +27,7 @@ func main() {
 	}
 
 	if flags.summary {
-		for _, l := range layers {
-			fmt.Printf("layer %s, version %d, extent %d, features %d\n", l.Name, l.Version, l.Extent, len(l.Features))
-		}
+		printLayersSummary(layers)
 		return
 	}
 

--- a/cmd/vt2geojson/main.go
+++ b/cmd/vt2geojson/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/golang/glog"
+)
+
+func main() {
+	flag.Parse()
+	defer glog.Flush()
+
+	if len(flags.mvtFile) > 0 {
+		//TODO: parse mvt file to geojson
+	}
+}

--- a/cmd/vt2geojson/main.go
+++ b/cmd/vt2geojson/main.go
@@ -5,32 +5,61 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
+	"strings"
 
 	"github.com/paulmach/orb/encoding/mvt"
 )
 
+func readMVTContent(mvtSource string) ([]byte, error) {
+
+	if strings.Index(mvtSource, "http") >= 0 { // download from URL
+		resp, err := http.Get(mvtSource)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		content, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		return content, nil
+	}
+
+	// otherwise read from file
+	content, err := ioutil.ReadFile(mvtSource)
+	if err != nil {
+		return nil, err
+	}
+	return content, nil
+}
+
 func main() {
 	flag.Parse()
 
-	if len(flags.mvtFile) > 0 {
-		//TODO: parse mvt file to geojson
-
-		content, err := ioutil.ReadFile(flags.mvtFile)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		layers, err := mvt.Unmarshal(content)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		if len(flags.layer) == 0 {
-			for _, l := range layers {
-				fmt.Printf("layer %s, version %d, extent %d, features %d\n", l.Name, l.Version, l.Extent, len(l.Features))
-			}
-			return
-		}
-		//fmt.Print(layers)
+	if len(flags.mvtSource) == 0 {
+		log.Fatalf("Please specify the mvt source by '-mvt'")
 	}
+
+	//TODO: parse mvt contents to geojson
+
+	content, err := readMVTContent(flags.mvtSource)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	layers, err := mvt.Unmarshal(content)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if len(flags.layer) == 0 {
+		for _, l := range layers {
+			fmt.Printf("layer %s, version %d, extent %d, features %d\n", l.Name, l.Version, l.Extent, len(l.Features))
+		}
+		return
+	}
+	//fmt.Print(layers)
 }

--- a/cmd/vt2geojson/mvt.go
+++ b/cmd/vt2geojson/mvt.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/paulmach/orb/encoding/mvt"
+)
+
+func loadMVT(mvtSource string) ([]byte, error) {
+
+	if strings.Index(mvtSource, "http") >= 0 { // download from URL
+		tr := &http.Transport{
+			DisableCompression: true, // disable the silently decompression
+		}
+		client := &http.Client{Transport: tr}
+		resp, err := client.Get(mvtSource)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		content, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		return content, nil
+	}
+
+	// otherwise read from file
+	content, err := ioutil.ReadFile(mvtSource)
+	if err != nil {
+		return nil, err
+	}
+	return content, nil
+}
+
+func unmarshalMVT(mvtContent []byte, gzipped bool) (mvt.Layers, error) {
+	if gzipped {
+		return mvt.UnmarshalGzipped(mvtContent)
+	}
+	return mvt.Unmarshal(mvtContent)
+}
+
+func printLayersSummary(layers mvt.Layers) {
+	for _, l := range layers {
+		fmt.Printf("layer %s, version %d, extent %d, features %d\n", l.Name, l.Version, l.Extent, len(l.Features))
+	}
+}


### PR DESCRIPTION
This is a command line tool to dump Mapbox Vector Tiles to GeoJSON.
It's similar with [mapbox/vt2geojson](https://github.com/mapbox/vt2geojson), but implemented by `Golang` and based on this library. 
I think it's good to have command line tool with library together, easy to use. Please consider whether it's ok for you. Thanks! 
