### PR TITLE
Fix nil pointer err when unmarshal geojson.Geometry

### DIFF
--- a/geojson/geometry.go
+++ b/geojson/geometry.go
@@ -104,7 +104,7 @@ func UnmarshalGeometry(data []byte) (*Geometry, error) {
 // UnmarshalJSON will unmarshal the correct geometry from the json structure.
 func (g *Geometry) UnmarshalJSON(data []byte) error {
 	jg := &jsonGeometry{}
-	err := json.Unmarshal(data, &jg)
+	err := json.Unmarshal(data, jg)
 	if err != nil {
 		return err
 	}

--- a/geojson/geometry_test.go
+++ b/geojson/geometry_test.go
@@ -179,6 +179,16 @@ func TestGeometryUnmarshal(t *testing.T) {
 	if err == nil {
 		t.Errorf("should return error for invalid json")
 	}
+
+	// invalid type (null)
+	_, err = UnmarshalGeometry([]byte(`null`))
+	if err == nil {
+		t.Errorf("should return error for invalid type")
+	}
+
+	if !strings.Contains(err.Error(), "invalid geometry") {
+		t.Errorf("incorrect error: %v", err)
+	}
 }
 
 func TestHelperTypes(t *testing.T) {


### PR DESCRIPTION
Nil pointer panic occurs when `UnmarshalGeometry([]byte("null"))`

For example, javascript `JSON.parse(null)` returns `null` value.
So I think `geojson.UnmarshalGeometry([]byte("null"))` should not panic.

and... why `jg := &jsonGeometry{}; json.Unmarshal(data, &jg)` seems double pointer...?
