### PR TITLE
fix missing Type after UnmarshalGeometry

### DIFF
--- a/geojson/geometry.go
+++ b/geojson/geometry.go
@@ -3,7 +3,6 @@ package geojson
 import (
 	"encoding/json"
 	"errors"
-
 	"github.com/paulmach/orb"
 )
 
@@ -139,6 +138,8 @@ func (g *Geometry) UnmarshalJSON(data []byte) error {
 	default:
 		return ErrInvalidGeometry
 	}
+
+	g.Type = g.Geometry().GeoJSONType()
 
 	return nil
 }

--- a/geojson/geometry_test.go
+++ b/geojson/geometry_test.go
@@ -147,6 +147,10 @@ func TestGeometryUnmarshal(t *testing.T) {
 				t.Errorf("unmarshal error: %v", err)
 			}
 
+			if g.Type != tc.geom.GeoJSONType() {
+				t.Errorf("incorrenct type: %v != %v", g.Type, tc.geom.GeoJSONType())
+			}
+
 			if !orb.Equal(g.Geometry(), tc.geom) {
 				t.Errorf("incorrect geometry")
 				t.Logf("%[1]T, %[1]v", g.Geometry())


### PR DESCRIPTION
Using `UnmarshalGeometry` resulted in geometries without a `Type`. The problem was caused by the `Unmarshaller` implementation of `Geometry`.