### PR TITLE
geojson: handle extra/foreign members in featureCollection

### DIFF
--- a/geojson/README.md
+++ b/geojson/README.md
@@ -14,12 +14,12 @@ The package also provides helper functions such as `UnmarshalFeatureCollection` 
 ```go
 rawJSON := []byte(`
   { "type": "FeatureCollection",
-	"features": [
-	  { "type": "Feature",
-		"geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
-		"properties": {"prop0": "value0"}
-	  }
-	]
+    "features": [
+      { "type": "Feature",
+        "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
+        "properties": {"prop0": "value0"}
+      }
+    ]
   }`)
 
 fc, _ := geojson.UnmarshalFeatureCollection(rawJSON)
@@ -43,6 +43,30 @@ rawJSON, _ := fc.MarshalJSON()
 
 // or
 blob, _ := json.Marshal(fc)
+```
+
+#### Foreign/extra members in a feature collection
+
+```go
+rawJSON := []byte(`
+  { "type": "FeatureCollection",
+    "generator": "myapp",
+    "timestamp": "2020-06-15T01:02:03Z",
+    "features": [
+      { "type": "Feature",
+        "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
+        "properties": {"prop0": "value0"}
+      }
+    ]
+  }`)
+
+fc, _ := geojson.UnmarshalFeatureCollection(rawJSON)
+
+fc.ExtraMembers["generator"] // == "myApp"
+fc.ExtraMembers["timestamp"] // == "2020-06-15T01:02:03Z"
+
+// Marshalling will include values in `ExtraMembers` in the
+// base featureCollection object.
 ```
 
 ## Feature Properties

--- a/geojson/bbox_test.go
+++ b/geojson/bbox_test.go
@@ -1,10 +1,22 @@
 package geojson
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/paulmach/orb"
 )
+
+func TestBBox(t *testing.T) {
+	ls := orb.LineString{{1, 3}, {0, 4}}
+	b := ls.Bound()
+
+	bbox := NewBBox(b)
+	expected := BBox{0, 3, 1, 4}
+	if !reflect.DeepEqual(bbox, expected) {
+		t.Errorf("incorrect result: %v != %v", bbox, expected)
+	}
+}
 
 func TestBBoxValid(t *testing.T) {
 	cases := []struct {

--- a/geojson/example_test.go
+++ b/geojson/example_test.go
@@ -28,29 +28,22 @@ func ExampleFeature_Point() {
 
 func ExampleFeatureCollection_foreignMembers() {
 	rawJSON := []byte(`
-  { "type": "FeatureCollection",
-	"features": [
-	  { "type": "Feature",
-		"geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
-		"properties": {"prop0": "value0"}
-	  }
-	],
-	"title": "Title as Foreign Member"
-  }`)
+	  { "type": "FeatureCollection",
+	    "features": [
+	      { "type": "Feature",
+	        "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
+	        "properties": {"prop0": "value0"}
+	      }
+	    ],
+	    "title": "Title as Foreign Member"
+	  }`)
 
-	type MyFeatureCollection struct {
-		geojson.FeatureCollection
-		Title string `json:"title"`
-	}
-
-	fc := &MyFeatureCollection{}
+	fc := geojson.NewFeatureCollection()
 	json.Unmarshal(rawJSON, &fc)
 
-	fmt.Println(fc.FeatureCollection.Features[0].Geometry)
 	fmt.Println(fc.Features[0].Geometry)
-	fmt.Println(fc.Title)
+	fmt.Println(fc.ExtraMembers["title"])
 	// Output:
-	// [102 0.5]
 	// [102 0.5]
 	// Title as Foreign Member
 }
@@ -120,7 +113,6 @@ func ExampleFeatureCollection_MarshalJSON() {
 
 	// Output:
 	// {
-	//  "type": "FeatureCollection",
 	//  "features": [
 	//   {
 	//    "type": "Feature",
@@ -133,6 +125,7 @@ func ExampleFeatureCollection_MarshalJSON() {
 	//    },
 	//    "properties": null
 	//   }
-	//  ]
+	//  ],
+	//  "type": "FeatureCollection"
 	// }
 }

--- a/geojson/feature.go
+++ b/geojson/feature.go
@@ -57,7 +57,7 @@ func (f Feature) MarshalJSON() ([]byte, error) {
 // Alternately one can call json.Unmarshal(f) directly for the same result.
 func UnmarshalFeature(data []byte) (*Feature, error) {
 	f := &Feature{}
-	err := json.Unmarshal(data, f)
+	err := f.UnmarshalJSON(data)
 	if err != nil {
 		return nil, err
 	}

--- a/geojson/feature_collection.go
+++ b/geojson/feature_collection.go
@@ -20,7 +20,8 @@ type FeatureCollection struct {
 	Features []*Feature `json:"features"`
 
 	// ExtraMembers can be used to encoded/decode extra key/members in
-	// the base of the feature collection.
+	// the base of the feature collection. Note that keys of "type", "bbox"
+	// and "features" will not work as those are reserved by the GeoJSON spec.
 	ExtraMembers Properties `json:"-"`
 }
 
@@ -41,6 +42,8 @@ func (fc *FeatureCollection) Append(feature *Feature) *FeatureCollection {
 // MarshalJSON converts the feature collection object into the proper JSON.
 // It will handle the encoding of all the child features and geometries.
 // Alternately one can call json.Marshal(fc) directly for the same result.
+// Items in the ExtraMembers map will be included in the base of the
+// feature collection object.
 func (fc FeatureCollection) MarshalJSON() ([]byte, error) {
 	var tmp map[string]interface{}
 	if fc.ExtraMembers != nil {
@@ -50,6 +53,7 @@ func (fc FeatureCollection) MarshalJSON() ([]byte, error) {
 	}
 
 	tmp["type"] = featureCollection
+	delete(tmp, "bbox")
 	if fc.BBox != nil {
 		tmp["bbox"] = fc.BBox
 	}
@@ -63,6 +67,7 @@ func (fc FeatureCollection) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON decodes the data into a GeoJSON feature collection.
+// Extra/foreign members will be put into the `ExtraMembers` attribute.
 func (fc *FeatureCollection) UnmarshalJSON(data []byte) error {
 	tmp := make(map[string]json.RawMessage, 4)
 

--- a/geojson/feature_collection.go
+++ b/geojson/feature_collection.go
@@ -69,7 +69,7 @@ func (fc FeatureCollection) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON decodes the data into a GeoJSON feature collection.
 // Extra/foreign members will be put into the `ExtraMembers` attribute.
 func (fc *FeatureCollection) UnmarshalJSON(data []byte) error {
-	tmp := make(map[string]json.RawMessage, 4)
+	tmp := make(map[string]nocopyRawMessage, 4)
 
 	err := json.Unmarshal(data, &tmp)
 	if err != nil {

--- a/geojson/feature_collection_test.go
+++ b/geojson/feature_collection_test.go
@@ -188,3 +188,34 @@ func TestFeatureCollectionMarshalValue(t *testing.T) {
 		t.Errorf("json should set features object to at least empty array")
 	}
 }
+
+func TestFeatureCollectionMarshalJSON_extraMembers(t *testing.T) {
+	rawJSON := `
+	  { "type": "FeatureCollection",
+		"foo": "bar",
+	    "features": [
+	      { "type": "Feature",
+	        "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
+	        "properties": {"prop0": "value0"}
+	      }
+	     ]
+	  }`
+
+	fc, err := UnmarshalFeatureCollection([]byte(rawJSON))
+	if err != nil {
+		t.Fatalf("should unmarshal feature collection without issue, err %v", err)
+	}
+
+	if v := fc.ExtraMembers.MustString("foo", ""); v != "bar" {
+		t.Errorf("missing extra: foo: %v", v)
+	}
+
+	data, err := fc.MarshalJSON()
+	if err != nil {
+		t.Fatalf("unable to marshal: %v", err)
+	}
+
+	if !bytes.Contains(data, []byte(`"foo":"bar"`)) {
+		t.Fatalf("extras not in marshalled data")
+	}
+}

--- a/geojson/feature_collection_test.go
+++ b/geojson/feature_collection_test.go
@@ -122,6 +122,55 @@ func TestUnmarshalFeatureCollection(t *testing.T) {
 	}
 }
 
+func TestUnmarshalFeatureCollection_errors(t *testing.T) {
+	t.Run("type not a string", func(t *testing.T) {
+		rawJSON := `
+		  { "type": { "foo":"bar" },
+		    "features": [
+		      { "type": "Feature",
+		        "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
+		        "properties": {"prop0": "value0"}
+		      }
+		     ]
+		  }`
+
+		_, err := UnmarshalFeatureCollection([]byte(rawJSON))
+		if _, ok := err.(*json.UnmarshalTypeError); !ok {
+			t.Fatalf("wrong error: %T: %v", err, err)
+		}
+	})
+
+	t.Run("bbox invalid", func(t *testing.T) {
+		rawJSON := `
+		  { "type": "FeatureCollection",
+		    "bbox": { "foo":"bar" },
+		    "features": [
+		      { "type": "Feature",
+		        "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
+		        "properties": {"prop0": "value0"}
+		      }
+		     ]
+		  }`
+
+		_, err := UnmarshalFeatureCollection([]byte(rawJSON))
+		if _, ok := err.(*json.UnmarshalTypeError); !ok {
+			t.Fatalf("wrong error: %T: %v", err, err)
+		}
+	})
+
+	t.Run("features invalid", func(t *testing.T) {
+		rawJSON := `
+		  { "type": "FeatureCollection",
+		    "features": { "foo":"bar" }
+		  }`
+
+		_, err := UnmarshalFeatureCollection([]byte(rawJSON))
+		if _, ok := err.(*json.UnmarshalTypeError); !ok {
+			t.Fatalf("wrong error: %T: %v", err, err)
+		}
+	})
+}
+
 func TestFeatureCollectionMarshalJSON(t *testing.T) {
 	fc := NewFeatureCollection()
 	blob, err := fc.MarshalJSON()

--- a/geojson/feature_test.go
+++ b/geojson/feature_test.go
@@ -3,6 +3,7 @@ package geojson
 import (
 	"bytes"
 	"encoding/json"
+	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -273,5 +274,44 @@ func TestMarshalRing(t *testing.T) {
 	if !bytes.Equal(data, []byte(`{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[0,0],[1,1],[2,1],[0,0]]]},"properties":null}`)) {
 		t.Errorf("data not correct")
 		t.Logf("%v", string(data))
+	}
+}
+
+func BenchmarkFeatureMarshalJSON(b *testing.B) {
+	data, err := ioutil.ReadFile("../encoding/mvt/testdata/16-17896-24449.json")
+	if err != nil {
+		b.Fatalf("could not open file: %v", err)
+	}
+
+	tile := map[string]*FeatureCollection{}
+	err = json.Unmarshal(data, &tile)
+	if err != nil {
+		b.Fatalf("could not unmarshal: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := json.Marshal(tile)
+		if err != nil {
+			b.Fatalf("marshal error: %v", err)
+		}
+	}
+}
+
+func BenchmarkFeatureUnmarshalJSON(b *testing.B) {
+	data, err := ioutil.ReadFile("../encoding/mvt/testdata/16-17896-24449.json")
+	if err != nil {
+		b.Fatalf("could not open file: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tile := map[string]*FeatureCollection{}
+		err = json.Unmarshal(data, &tile)
+		if err != nil {
+			b.Fatalf("could not unmarshal: %v", err)
+		}
 	}
 }

--- a/geojson/properties.go
+++ b/geojson/properties.go
@@ -103,7 +103,7 @@ func (p Properties) MustString(key string, def ...string) string {
 
 // Clone returns a shallow copy of the properties.
 func (p Properties) Clone() Properties {
-	n := make(Properties, len(p))
+	n := make(Properties, len(p)+3)
 	for k, v := range p {
 		n[k] = v
 	}

--- a/json_test.go
+++ b/json_test.go
@@ -61,3 +61,166 @@ func TestLineStringJSON(t *testing.T) {
 		t.Errorf("incorrect json: %v", string(data))
 	}
 }
+
+var pointData = []byte(`[-81.60540868,41.51522539]`)
+
+var lineStringShortData = []byte(`[
+		[-81.60540868,41.51522539],[-81.6049915,41.51523057],
+		[-81.60499258,41.51528156],[-81.60506867,41.51528061],
+		[-81.60540868,41.51522539]
+	]`)
+var lineStringLongData = []byte(`[
+		[-81.60540868,41.51522539],[-81.6049915,41.51523057],
+		[-81.60499258,41.51528156],[-81.60506867,41.51528061],
+		[-81.60507145,41.5154027],[-81.60500219,41.51540351],
+		[-81.60500345,41.51545786],[-81.60529819,41.51545416],
+		[-81.60530133,41.51559117],[-81.60487193,41.51559662],
+		[-81.60486062,41.51508837],[-81.60521401,41.515084],
+		[-81.60521123,41.51495707],[-81.60480788,41.51496219],
+		[-81.6047998,41.51460138],[-81.60496455,41.51459936],
+		[-81.60496778,41.51474909],[-81.6053979,41.51474371],
+		[-81.60540868,41.51522539]
+	]`)
+var polygonShortData = append(append([]byte{'['}, lineStringShortData...), byte(']'))
+var polygonLongData = append(append([]byte{'['}, lineStringLongData...), byte(']'))
+
+func BenchmarkPointMarshalJSON(b *testing.B) {
+	p := Point{}
+	if err := json.Unmarshal(pointData, &p); err != nil {
+		b.Fatalf("unable to unmarshal: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := json.Marshal(p)
+		if err != nil {
+			b.Fatalf("marshal error: %v", err)
+		}
+	}
+}
+
+func BenchmarkPointUnmarshalJSON(b *testing.B) {
+	p := Point{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := json.Unmarshal(pointData, &p)
+		if err != nil {
+			b.Fatalf("marshal error: %v", err)
+		}
+	}
+}
+
+func BenchmarkLineStringMarshalJSON_short(b *testing.B) {
+	ls := LineString{}
+	if err := json.Unmarshal(lineStringShortData, &ls); err != nil {
+		b.Fatalf("unable to unmarshal: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := json.Marshal(ls)
+		if err != nil {
+			b.Fatalf("marshal error: %v", err)
+		}
+	}
+}
+
+func BenchmarkLineStringUnmarshalJSON_short(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ls := LineString{}
+		err := json.Unmarshal(lineStringShortData, &ls)
+		if err != nil {
+			b.Fatalf("marshal error: %v", err)
+		}
+	}
+}
+
+func BenchmarkLineStringMarshalJSON_long(b *testing.B) {
+	ls := LineString{}
+	if err := json.Unmarshal(lineStringLongData, &ls); err != nil {
+		b.Fatalf("unable to unmarshal: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := json.Marshal(ls)
+		if err != nil {
+			b.Fatalf("marshal error: %v", err)
+		}
+	}
+}
+
+func BenchmarkLineStringUnmarshalJSON_long(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ls := LineString{}
+		err := json.Unmarshal(lineStringLongData, &ls)
+		if err != nil {
+			b.Fatalf("marshal error: %v", err)
+		}
+	}
+}
+
+func BenchmarkPolygonMarshalJSON_short(b *testing.B) {
+	p := Polygon{}
+	if err := json.Unmarshal(polygonShortData, &p); err != nil {
+		b.Fatalf("unable to unmarshal: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := json.Marshal(p)
+		if err != nil {
+			b.Fatalf("marshal error: %v", err)
+		}
+	}
+}
+
+func BenchmarkPolygonUnmarshalJSON_short(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p := Polygon{}
+		err := json.Unmarshal(polygonShortData, &p)
+		if err != nil {
+			b.Fatalf("marshal error: %v", err)
+		}
+	}
+}
+
+func BenchmarkPolygonMarshalJSON_long(b *testing.B) {
+	p := Polygon{}
+	if err := json.Unmarshal(polygonLongData, &p); err != nil {
+		b.Fatalf("unable to unmarshal: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := json.Marshal(p)
+		if err != nil {
+			b.Fatalf("marshal error: %v", err)
+		}
+	}
+}
+
+func BenchmarkPolygonUnmarshalJSON_long(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p := Polygon{}
+		err := json.Unmarshal(polygonLongData, &p)
+		if err != nil {
+			b.Fatalf("marshal error: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Foreign Members are those that aren’t in the [spec](https://tools.ietf.org/html/rfc7946#section-6.1). i.e. properties in the feature collection object that aren’t the big 3, `type`,`bbox` and `features`.

Support for this has been requested 3 times. https://github.com/paulmach/orb/issues/1 https://github.com/paulmach/orb/issues/13 https://github.com/paulmach/orb/issues/42 

This PR adds full support to those features by storing them in a `ExtraMembers` map in the feature collection.  These members will be encoded/decoded to/from the base feature collection as expected.

## Concerns
There was an [example](https://github.com/paulmach/orb/blob/bc42fc7d84cfdbf6ca86b63f5580a9641a2f4797/geojson/example_test.go#L29-L56) and [issue response](https://github.com/paulmach/orb/issues/1) suggesting to embed a feature collection in another object like so
```go
type MyFeatureCollection struct {
	geojson.FeatureCollection
	Title string `json:"title"`
}
```
**This approach will no longer work** and has been abandoned because marshaling/encoding was not supported. To maintain this behavior one can add a `UnmarshalJSON()` method on the new struct type like so:
```go
func (fc *MyFeatureCollection) UnmarshalJSON(data []byte) error {
	err := json.Unmarshal(data, &fc.FeatureCollection)
	if err != nil {
		return err
	}

	fc.Title = fc.ExtraMembers.MustString("title", "")
	fc.ExtraMembers = nil
	return nil
}
```
Note: you could still do this to keep things type safe but the reverse `MarshalJSON` would also need to be implemented for encoding to work.

## Performance
Benchmarks did no show any meaningful change in performance after this change.