### PR TITLE
geojson: don't error on nil geometry

### DIFF
--- a/geojson/feature.go
+++ b/geojson/feature.go
@@ -78,8 +78,12 @@ func (f *Feature) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("geojson: not a feature: type=%s", jf.Type)
 	}
 
-	if jf.Geometry == nil || (jf.Geometry.Coordinates == nil && jf.Geometry.Geometries == nil) {
-		return ErrInvalidGeometry
+	var g orb.Geometry
+	if jf.Geometry != nil {
+		if jf.Geometry.Coordinates == nil && jf.Geometry.Geometries == nil {
+			return ErrInvalidGeometry
+		}
+		g = jf.Geometry.Geometry()
 	}
 
 	*f = Feature{
@@ -87,7 +91,7 @@ func (f *Feature) UnmarshalJSON(data []byte) error {
 		Type:       jf.Type,
 		Properties: jf.Properties,
 		BBox:       jf.BBox,
-		Geometry:   jf.Geometry.Geometry(),
+		Geometry:   g,
 	}
 
 	return nil

--- a/geojson/feature_test.go
+++ b/geojson/feature_test.go
@@ -177,9 +177,13 @@ func TestUnmarshalFeature_missingGeometry(t *testing.T) {
 	t.Run("missing geometry", func(t *testing.T) {
 		rawJSON := `{ "type": "Feature" }`
 
-		_, err := UnmarshalFeature([]byte(rawJSON))
-		if err != ErrInvalidGeometry {
-			t.Fatalf("incorrect unmarshal error: %v", err)
+		f, err := UnmarshalFeature([]byte(rawJSON))
+		if err != nil {
+			t.Fatalf("should not error: %v", err)
+		}
+
+		if f == nil {
+			t.Fatalf("feature should not be nil")
 		}
 	})
 }


### PR DESCRIPTION
As discussed in https://github.com/paulmach/orb/issues/38#issuecomment-760811266

nil/missing Geometry in a GeoJSON is valid according to the spec https://tools.ietf.org/html/rfc7946#section-3.2

This will change behavior as previous it would fail, now it just silently continues.