### PR TITLE
add a panicing test case to quadtree/quadtree_test.go/TestQuadTreeMatching

### DIFF
--- a/quadtree/quadtree_test.go
+++ b/quadtree/quadtree_test.go
@@ -136,6 +136,12 @@ func TestQuadtreeMatching(t *testing.T) {
 			point:    orb.Point{0.1, 0.1},
 			expected: orb.Point{1, 1},
 		},
+		{
+			name:     "match none filter",
+			filter:   func(p orb.Pointer) bool { return false },
+			point:    orb.Point{0.1, 0.1},
+			expected: orb.Point{1, 1},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
this test case panics because in quadtree/quadtree.go does not check
if the `findVisitor.closest` value is nil before returning
`v.closest.Value` at the end of the method.

a fix here is not straight forward because the method signature does not
return `error`. It's possible that we could add a `type orb.NilPointer`
[ ugh naming ] that satisfies the orb.Poitner interface but could be
returned without breaking existing clients