### PR TITLE
encoding/mvt: verify tile coord does not overflow for z > 20

### DIFF
--- a/encoding/mvt/projection.go
+++ b/encoding/mvt/projection.go
@@ -20,8 +20,8 @@ func newProjection(tile maptile.Tile, extent uint32) *projection {
 		n := uint32(bits.TrailingZeros32(extent))
 		z := uint32(tile.Z) + n
 
-		minx := float64(tile.X << n)
-		miny := float64(tile.Y << n)
+		minx := float64(uint64(tile.X) << n)
+		miny := float64(uint64(tile.Y) << n)
 		return &projection{
 			ToTile: func(p orb.Point) orb.Point {
 				x, y := mercator.ToPlanar(p[0], p[1], z)

--- a/encoding/mvt/projection_test.go
+++ b/encoding/mvt/projection_test.go
@@ -1,11 +1,40 @@
 package mvt
 
 import (
+	"math"
 	"testing"
 
 	"github.com/paulmach/orb/maptile"
 	"github.com/paulmach/orb/project"
 )
+
+func TestPowerOfTwoProjection(t *testing.T) {
+	const epsilon = 1e-6
+
+	// verify tile coord does not overflow int32
+	tile := maptile.New(1730576, 798477, 21)
+	proj := newProjection(tile, 4096)
+
+	center := tile.Center()
+	planar := proj.ToTile(center)
+
+	if planar[0] != 2048 {
+		t.Errorf("incorrect lon projection: %v", planar[0])
+	}
+
+	if planar[1] != 2048 {
+		t.Errorf("incorrect lat projection: %v", planar[1])
+	}
+
+	geo := proj.ToWGS84(planar)
+	if math.Abs(geo[0]-center[0]) > epsilon {
+		t.Errorf("lon miss match: %f != %f", geo[0], center[0])
+	}
+
+	if math.Abs(geo[1]-center[1]) > epsilon {
+		t.Errorf("lat miss match: %f != %f", geo[1], center[1])
+	}
+}
 
 func TestNonPowerOfTwoProjection(t *testing.T) {
 	tile := maptile.New(8956, 12223, 15)

--- a/internal/mercator/mercator.go
+++ b/internal/mercator/mercator.go
@@ -28,7 +28,7 @@ var (
 
 // ToPlanar converts the point to geo world coordinates at the given live.
 func ToPlanar(lng, lat float64, level uint32) (x, y float64) {
-	maxtiles := float64(uint32(1 << level))
+	maxtiles := float64(uint64(1 << level))
 	x = (lng/360.0 + 0.5) * maxtiles
 
 	// bound it because we have a top of the world problem
@@ -48,7 +48,7 @@ func ToPlanar(lng, lat float64, level uint32) (x, y float64) {
 
 // ToGeo projects world coordinates back to geo coordinates.
 func ToGeo(x, y float64, level uint32) (lng, lat float64) {
-	maxtiles := float64(uint32(1 << level))
+	maxtiles := float64(uint64(1 << level))
 
 	lng = 360.0 * (x/maxtiles - 0.5)
 	lat = 2.0*math.Atan(math.Exp(math.Pi-(2*math.Pi)*(y/maxtiles)))*(180.0/math.Pi) - 90.0

--- a/internal/mercator/mercator_test.go
+++ b/internal/mercator/mercator_test.go
@@ -26,10 +26,18 @@ func TestScalarMercator(t *testing.T) {
 		t.Errorf("Scalar Mercator, projection incorrect, got %v %v", x, y)
 	}
 
-	// default level
+	// testing level > 32 to verify correct type conversion
 	for _, city := range Cities {
-		x, y := ToPlanar(city[1], city[0], 31)
-		lng, lat = ToGeo(x, y, 31)
+		x, y := ToPlanar(city[1], city[0], 35)
+		lng, lat = ToGeo(x, y, 35)
+
+		if math.IsNaN(lng) {
+			t.Error("Scalar Mercator, lng is NaN")
+		}
+
+		if math.IsNaN(lat) {
+			t.Error("Scalar Mercator, lat is NaN")
+		}
 
 		if math.Abs(lat-city[0]) > Epsilon {
 			t.Errorf("Scalar Mercator, latitude miss match: %f != %f", lat, city[0])
@@ -41,11 +49,11 @@ func TestScalarMercator(t *testing.T) {
 	}
 
 	// test polar regions
-	if _, y := ToPlanar(0, 89.9, 31); y != (1<<31)-1 {
+	if _, y := ToPlanar(0, 89.9, 32); y != (1<<32)-1 {
 		t.Errorf("Scalar Mercator, top of the world error, got %v", y)
 	}
 
-	if _, y := ToPlanar(0, -89.9, 31); y != 0 {
+	if _, y := ToPlanar(0, -89.9, 32); y != 0 {
 		t.Errorf("Scalar Mercator, bottom of the world error, got %v", y)
 	}
 }


### PR DESCRIPTION
fixes https://github.com/paulmach/orb/issues/71

Due to the use of uint32 types, there is an overflow when going from zoom > 20 tiles to the z+12 tile coord space. That space could be 33+ bits, so need a bigger type.

