### PR TITLE
encoding/wkb: handle mysql point scanning when SRID is 0

### DIFF
--- a/encoding/wkb/scanner.go
+++ b/encoding/wkb/scanner.go
@@ -229,6 +229,18 @@ func scanPoint(data []byte) (orb.Point, error) {
 		return orb.Point{}, err
 	}
 
+	// Checking for MySQL's SRID+WKB format where the SRID is 0.
+	// Common SRIDs would be handled in the unmarshalByteOrderType above.
+	if len(data) == 25 &&
+		data[0] == 0 && data[1] == 0 && data[2] == 0 && data[3] == 0 {
+
+		data = data[4:]
+		order, typ, data, err = unmarshalByteOrderType(data)
+		if err != nil {
+			return orb.Point{}, err
+		}
+	}
+
 	switch typ {
 	case pointType:
 		return unmarshalPoint(order, data[5:])

--- a/encoding/wkb/scanner_test.go
+++ b/encoding/wkb/scanner_test.go
@@ -100,6 +100,11 @@ func TestScanPoint(t *testing.T) {
 			expected: testPoint,
 		},
 		{
+			name:     "point with 0 SRID",
+			data:     append([]byte{0, 0, 0, 0}, testPointData...),
+			expected: testPoint,
+		},
+		{
 			name:     "single multi-point",
 			data:     testMultiPointSingleData,
 			expected: testMultiPointSingle[0],


### PR DESCRIPTION
a wkb point is 21 bytes. mysql prefixes it with the SRID. The code to handle these 25 byte cases was not working if the SRID is 0 (default?).

Fixes https://github.com/paulmach/orb/issues/79