### PR TITLE
wkb encoding/decoder for working with mysql/mariadb queries

### DIFF
--- a/encoding/wkb/README.md
+++ b/encoding/wkb/README.md
@@ -43,7 +43,19 @@ case orb.LineString:
 }
 ```
 
-Scanning directly from MySQL columns is supported. By default MySQL returns geometry
-data as WKB but prefixed with a 4 byte SRID. To support this, if the data is not
-valid WKB, the code will strip the first 4 bytes, the SRID, and try again.
-This works for most use cases.
+## MySQL or MariaDB
+
+By default MySQL returns geometry data as WKB but prefixed with a 4 byte SRID.
+This is supported using the `MySQLScanner` and `MySQLValue`. For example:
+
+```go
+db.Exec("INSERT INTO geotest(id, geom) VALUES (?, ?)", 1, wkb.MySQLValue(orb.Point{1, 1}))
+```
+
+Reading of MySQL point data is supported using the regular scanner but other types may have issues.
+For best results use `MySQLScanner` to handle the 4 byte SRID prefix.
+
+```go
+var p orb.Point
+rows, err := db.QueryRow("SELECT geom FROM geotest").Scan(wkb.MySQLScanner(p))
+```

--- a/encoding/wkb/scanner_test.go
+++ b/encoding/wkb/scanner_test.go
@@ -1033,6 +1033,48 @@ func TestValue_nil(t *testing.T) {
 	}
 }
 
+func TestMySQLScanner(t *testing.T) {
+	cases := []struct {
+		name   string
+		data   []byte
+		result orb.Geometry
+		srid   int
+	}{
+		{
+			name:   "zero srid",
+			data:   []byte{0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 240, 63, 0, 0, 0, 0, 0, 0, 240, 63},
+			result: orb.Point{1, 1},
+			srid:   0,
+		},
+		{
+			name:   "zero 4326",
+			data:   []byte{230, 16, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 240, 63, 0, 0, 0, 0, 0, 0, 240, 63},
+			result: orb.Point{1, 1},
+			srid:   4326,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := MySQLScanner(nil)
+			err := s.Scan(tc.data)
+			if err != nil {
+				t.Errorf("scan error: %v", err)
+			}
+
+			if s.SRID != tc.srid {
+				t.Errorf("incorrect SRID: %v != %v", s.SRID, tc.srid)
+			}
+
+			if !reflect.DeepEqual(s.Geometry, tc.result) {
+				t.Logf("%v", s.Geometry)
+				t.Logf("%v", tc.result)
+				t.Errorf("incorrect geometry")
+			}
+		})
+	}
+}
+
 func TestMySQLValue(t *testing.T) {
 	cases := []struct {
 		name   string


### PR DESCRIPTION
Addresses issues seen with https://github.com/paulmach/orb/issues/79 and https://github.com/paulmach/orb/issues/61

Basically, mysql/mariadb prefix the 4 byte srid. This PR adds helpers to deal with that.

For Insert you need to use WKT or prefix your binary data with that 4 bytes. `wkb.MySQLValue(orb.Point{1, 1}, optionalSRID)` helps with that.

For reading you can `ST_asBinary` or use the `wkb.MySQLScanner(p)`

See the readme updates in the PR for more details.
