### PR TITLE
encoding/mvt: stable marshalling

### DIFF
--- a/encoding/mvt/geometry.go
+++ b/encoding/mvt/geometry.go
@@ -138,6 +138,8 @@ type keyValueEncoder struct {
 
 	Values   []*vectortile.Tile_Value
 	valueMap map[interface{}]uint32
+
+	keySortBuffer []string
 }
 
 func newKeyValueEncoder() *keyValueEncoder {

--- a/encoding/mvt/marshal.go
+++ b/encoding/mvt/marshal.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
+	"sort"
 	"strconv"
 
 	"github.com/paulmach/orb/encoding/mvt/vectortile"
@@ -84,9 +85,16 @@ func Marshal(layers Layers) ([]byte, error) {
 
 func encodeProperties(kve *keyValueEncoder, properties geojson.Properties) ([]uint32, error) {
 	tags := make([]uint32, 0, 2*len(properties))
-	for k, v := range properties {
+
+	keys := make([]string, 0, len(properties))
+	for k := range properties {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
 		ki := kve.Key(k)
-		vi, err := kve.Value(v)
+		vi, err := kve.Value(properties[k])
 		if err != nil {
 			return nil, fmt.Errorf("property %s: %v", k, err)
 		}

--- a/encoding/mvt/marshal.go
+++ b/encoding/mvt/marshal.go
@@ -86,13 +86,13 @@ func Marshal(layers Layers) ([]byte, error) {
 func encodeProperties(kve *keyValueEncoder, properties geojson.Properties) ([]uint32, error) {
 	tags := make([]uint32, 0, 2*len(properties))
 
-	keys := make([]string, 0, len(properties))
+	kve.keySortBuffer = kve.keySortBuffer[:0]
 	for k := range properties {
-		keys = append(keys, k)
+		kve.keySortBuffer = append(kve.keySortBuffer, k)
 	}
-	sort.Strings(keys)
+	sort.Strings(kve.keySortBuffer)
 
-	for _, k := range keys {
+	for _, k := range kve.keySortBuffer {
 		ki := kve.Key(k)
 		vi, err := kve.Value(properties[k])
 		if err != nil {

--- a/encoding/mvt/marshal_test.go
+++ b/encoding/mvt/marshal_test.go
@@ -1,6 +1,8 @@
 package mvt
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -467,6 +469,22 @@ func TestMarshal_ID(t *testing.T) {
 			t.Errorf("should unmarshal id to float64: %T", id)
 		}
 	})
+}
+
+func TestStableMarshalling(t *testing.T) {
+	layers := NewLayers(loadGeoJSON(t, maptile.New(17896, 24449, 16)))
+	values := make(map[string]bool)
+
+	for i := 0; i < 100; i++ {
+		marshal, _ := Marshal(layers)
+		checksum := md5.Sum(marshal)
+		sum := hex.EncodeToString(checksum[:])
+		values[sum] = true
+	}
+
+	if len(values) != 1 {
+		t.Errorf("multiple values (%d) for marshalled bytes", len(values))
+	}
 }
 
 func BenchmarkMarshal(b *testing.B) {


### PR DESCRIPTION
Hi!  We've been using the library and are big fans.  I've noticed one opportunity to (potentially) improve things.  I'm trying to take an MD5 hash of the marshaled bytes to use as a fingerprint that I can compare with what the client sends me to see if they match, and it doesn't work quite right.

Currently, encode_properties iterates over a map to encode. Since there are no guarantees on iteration order for go maps, the output can differ each time for the same input. In practice, I've found the iteration order to be different almost every time.

func TestStableMarshalling(t *testing.T) {
	layers := NewLayers(loadGeoJSON(t, maptile.New(17896, 24449, 16)))
	values := make(map[string]bool)

	for i := 0; i < 100; i++ {
		marshal, _ := Marshal(layers)
		checksum := md5.Sum(marshal)
		sum := hex.EncodeToString(checksum[:])
		values[sum] = true
	}

	if len(values) != 1 {
		t.Errorf("multiple values (%d) for marshalled bytes", len(values))
	}
}
The above test will typically produce 100 different md5 values.

This change makes encode_properties stable by getting the keys to the map, sorting them, and iterating over them.  The benchmark numbers are:

Unstable:
```
BenchmarkMarshal
BenchmarkMarshal-16          	    1819	    606970 ns/op	  368286 B/op	    4790 allocs/op
BenchmarkUnmarshal
BenchmarkUnmarshal-16        	    4959	    245290 ns/op	  208822 B/op	    2468 allocs/op
BenchmarkProjectToTile
BenchmarkProjectToTile-16    	   14942	     80458 ns/op	    6672 B/op	     309 allocs/op
BenchmarkProjectToGeo
BenchmarkProjectToGeo-16     	   19521	     64411 ns/op	    6672 B/op	     309 allocs/op
PASS
```

Stable:
```
BenchmarkMarshal
BenchmarkMarshal-16          	    1363	    817600 ns/op	  411622 B/op	    5354 allocs/op
BenchmarkUnmarshal
BenchmarkUnmarshal-16        	    4479	    245967 ns/op	  208905 B/op	    2468 allocs/op
BenchmarkProjectToTile
BenchmarkProjectToTile-16    	   15022	     83612 ns/op	    6672 B/op	     309 allocs/op
BenchmarkProjectToGeo
BenchmarkProjectToGeo-16     	   19256	     61878 ns/op	    6672 B/op	     309 allocs/op
PASS
```

I'm happy to go whatever route you'd prefer here.  I understand you may not want to impact the perf since the stability hasn't mattered up to now.   I can perhaps add a separate method like `MarshalStable`?

Much appreciated!