### PR TITLE
quadtree: fix cleanup of nodes during removal

### DIFF
--- a/quadtree/quadtree.go
+++ b/quadtree/quadtree.go
@@ -171,6 +171,9 @@ func removeNode(n *node) {
 
 	n.Value = n.Children[i].Value
 	removeNode(n.Children[i])
+	if n.Children[i].Value == nil {
+		n.Children[i] = nil
+	}
 }
 
 // Find returns the closest Value/Pointer in the quadtree.

--- a/quadtree/quadtree_test.go
+++ b/quadtree/quadtree_test.go
@@ -56,6 +56,55 @@ func TestQuadtreeRemove(t *testing.T) {
 	}
 }
 
+type PExtra struct {
+	p  orb.Point
+	id string
+}
+
+func (p *PExtra) Point() orb.Point {
+	return p.p
+}
+
+func TestQuadtreeRemoveAndAdd(t *testing.T) {
+	r := rand.New(rand.NewSource(42))
+
+	qt := New(orb.Bound{Min: orb.Point{0, 0}, Max: orb.Point{1, 1}})
+	p0 := &PExtra{p: orb.Point{r.Float64(), r.Float64()}, id: "0"}
+	p1 := &PExtra{p: orb.Point{p0.p[0], p0.p[1]}, id: "1"}
+	p2 := &PExtra{p: orb.Point{p0.p[0], p0.p[1]}, id: "2"}
+	p3 := &PExtra{p: orb.Point{p0.p[0], p0.p[1]}, id: "3"}
+
+	qt.Add(p0)
+	qt.Add(p1)
+	qt.Add(p2)
+	found := qt.Remove(p1, func(p orb.Pointer) bool {
+		return p.(*PExtra).id == p1.id
+	})
+	if !found {
+		t.Error("didn't find point")
+	}
+	found = qt.Remove(p0, func(p orb.Pointer) bool {
+		return p.(*PExtra).id == p0.id
+	})
+	if !found {
+		t.Error("didn't find point")
+	}
+	qt.Add(p3)
+	found = qt.Remove(p2, func(p orb.Pointer) bool {
+		return p.(*PExtra).id == p2.id
+	})
+	if !found {
+		t.Error("didn't find point")
+	}
+	found = qt.Remove(p3, func(p orb.Pointer) bool {
+		return p.(*PExtra).id == p3.id
+	})
+	if !found {
+		t.Error("didn't find point")
+	}
+
+}
+
 func TestQuadtreeFind(t *testing.T) {
 	points := orb.MultiPoint{}
 	dim := 17


### PR DESCRIPTION
This PR fixes issues brought up by @hades32 in https://github.com/paulmach/orb/pull/90

Parts of the tree were getting pruned during removal, the cause is something like:
1. remove a value that was stored in a leaf node. This would make the node's value nil, but not remove the node.
2. adding some values would/could create children of this nil-value node. So you had have a nil-value node in the middle of the tree.
3. when removing a value in a parent of the original node the `removeNode` code would recurse down, find this nil-value node and remove it, along with everything under it. 

The main bug is that when adding nodes in 2, existing nil-value nodes were not reused. Also I'm unsure about the the previous removeNode code working properly.

The code assumes nil-value nodes are only in leafs. So on add we reuse nil-value nodes instead of jumping over them (reuse leaf nil-value nodes). On remove, we "pull-up" values to fill in the nil-value node caused by the removal that is in the middle of the tree.