### PR TITLE
geojson: add support for "external" json encoders/decoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ for _, f := range fc {
 }
 ```
 
+The library supports third party "encoding/json" replacements
+such [github.com/json-iterator/go](https://github.com/json-iterator/go).
+See the [geojson](geojson) readme for more details.
+
 ## Mapbox Vector Tiles
 
 The [encoding/mvt](encoding/mvt) sub-package implements Marshalling and

--- a/geojson/README.md
+++ b/geojson/README.md
@@ -66,6 +66,53 @@ fc.ExtraMembers["timestamp"] // == "2020-06-15T01:02:03Z"
 // base featureCollection object.
 ```
 
+## Performance Performance Performance
+
+If GeoJSON encoding/decoding performance is critical consider using a
+third party replacement of "encoding/json" like [github.com/json-iterator/go](https://github.com/json-iterator/go)
+
+This can be enabled with something like this:
+
+```go
+import (
+  jsoniter "github.com/json-iterator/go"
+  "github.com/paulmach/orb"
+)
+
+var c = jsoniter.Config{
+  EscapeHTML:              true,
+  SortMapKeys:             false,
+  ValidateJsonRawMessage:  false,
+  MarshalFloatWith6Digits: true,
+}.Froze()
+
+CustomJSONMarshaler = c
+CustomJSONUnmarshaler = c
+```
+
+The above change can have dramatic performance implications, see the benchmarks below
+on a 100k feature collection file:
+
+```
+benchmark                             old ns/op     new ns/op     delta
+BenchmarkFeatureMarshalJSON-12        2694543       733480        -72.78%
+BenchmarkFeatureUnmarshalJSON-12      5383825       2738183       -49.14%
+BenchmarkGeometryMarshalJSON-12       210107        62789         -70.12%
+BenchmarkGeometryUnmarshalJSON-12     691472        144689        -79.08%
+
+benchmark                             old allocs     new allocs     delta
+BenchmarkFeatureMarshalJSON-12        7818           2316           -70.38%
+BenchmarkFeatureUnmarshalJSON-12      23047          31946          +38.61%
+BenchmarkGeometryMarshalJSON-12       2              3              +50.00%
+BenchmarkGeometryUnmarshalJSON-12     2042           18             -99.12%
+
+benchmark                             old bytes     new bytes     delta
+BenchmarkFeatureMarshalJSON-12        794088        490251        -38.26%
+BenchmarkFeatureUnmarshalJSON-12      766354        1068497       +39.43%
+BenchmarkGeometryMarshalJSON-12       24787         18650         -24.76%
+BenchmarkGeometryUnmarshalJSON-12     79784         51374         -35.61%
+```
+
 ## Feature Properties
 
 GeoJSON features can have properties of any type. This can cause issues in a statically typed
@@ -78,4 +125,8 @@ f.Properties.MustBool(key string, def ...bool) bool
 f.Properties.MustFloat64(key string, def ...float64) float64
 f.Properties.MustInt(key string, def ...int) int
 f.Properties.MustString(key string, def ...string) string
+```
+
+```
+
 ```

--- a/geojson/README.md
+++ b/geojson/README.md
@@ -66,9 +66,9 @@ fc.ExtraMembers["timestamp"] // == "2020-06-15T01:02:03Z"
 // base featureCollection object.
 ```
 
-## Performance Performance Performance
+## Performance
 
-If GeoJSON encoding/decoding performance is critical consider using a
+For performance critical applications, consider a
 third party replacement of "encoding/json" like [github.com/json-iterator/go](https://github.com/json-iterator/go)
 
 This can be enabled with something like this:
@@ -82,7 +82,6 @@ import (
 var c = jsoniter.Config{
   EscapeHTML:              true,
   SortMapKeys:             false,
-  ValidateJsonRawMessage:  false,
   MarshalFloatWith6Digits: true,
 }.Froze()
 
@@ -125,8 +124,4 @@ f.Properties.MustBool(key string, def ...bool) bool
 f.Properties.MustFloat64(key string, def ...float64) float64
 f.Properties.MustInt(key string, def ...int) int
 f.Properties.MustString(key string, def ...string) string
-```
-
-```
-
 ```

--- a/geojson/feature.go
+++ b/geojson/feature.go
@@ -1,7 +1,6 @@
 package geojson
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/paulmach/orb"
@@ -50,7 +49,7 @@ func (f Feature) MarshalJSON() ([]byte, error) {
 		jf.Properties = nil
 	}
 
-	return json.Marshal(jf)
+	return marshalJSON(jf)
 }
 
 // UnmarshalFeature decodes the data into a GeoJSON feature.
@@ -69,7 +68,7 @@ func UnmarshalFeature(data []byte) (*Feature, error) {
 // into the orb.Geometry types.
 func (f *Feature) UnmarshalJSON(data []byte) error {
 	jf := &jsonFeature{}
-	err := json.Unmarshal(data, &jf)
+	err := unmarshalJSON(data, &jf)
 	if err != nil {
 		return err
 	}

--- a/geojson/feature_collection.go
+++ b/geojson/feature_collection.go
@@ -7,7 +7,6 @@ json.Unmarshaler interfaces as well as helper functions such as
 package geojson
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
@@ -63,7 +62,7 @@ func (fc FeatureCollection) MarshalJSON() ([]byte, error) {
 		tmp["features"] = fc.Features
 	}
 
-	return json.Marshal(tmp)
+	return marshalJSON(tmp)
 }
 
 // UnmarshalJSON decodes the data into a GeoJSON feature collection.
@@ -71,7 +70,7 @@ func (fc FeatureCollection) MarshalJSON() ([]byte, error) {
 func (fc *FeatureCollection) UnmarshalJSON(data []byte) error {
 	tmp := make(map[string]nocopyRawMessage, 4)
 
-	err := json.Unmarshal(data, &tmp)
+	err := unmarshalJSON(data, &tmp)
 	if err != nil {
 		return err
 	}
@@ -80,17 +79,17 @@ func (fc *FeatureCollection) UnmarshalJSON(data []byte) error {
 	for key, value := range tmp {
 		switch key {
 		case "type":
-			err := json.Unmarshal(value, &fc.Type)
+			err := unmarshalJSON(value, &fc.Type)
 			if err != nil {
 				return err
 			}
 		case "bbox":
-			err := json.Unmarshal(value, &fc.BBox)
+			err := unmarshalJSON(value, &fc.BBox)
 			if err != nil {
 				return err
 			}
 		case "features":
-			err := json.Unmarshal(value, &fc.Features)
+			err := unmarshalJSON(value, &fc.Features)
 			if err != nil {
 				return err
 			}
@@ -100,7 +99,7 @@ func (fc *FeatureCollection) UnmarshalJSON(data []byte) error {
 			}
 
 			var val interface{}
-			err := json.Unmarshal(value, &val)
+			err := unmarshalJSON(value, &val)
 			if err != nil {
 				return err
 			}

--- a/geojson/feature_collection_test.go
+++ b/geojson/feature_collection_test.go
@@ -84,7 +84,7 @@ func TestUnmarshalFeatureCollection(t *testing.T) {
 
 	// check unmarshal/marshal loop
 	var expected interface{}
-	err = json.Unmarshal([]byte(rawJSON), &expected)
+	err = unmarshalJSON([]byte(rawJSON), &expected)
 	if err != nil {
 		t.Fatalf("unmarshal error: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestUnmarshalFeatureCollection(t *testing.T) {
 	}
 
 	var raw interface{}
-	err = json.Unmarshal(data, &raw)
+	err = unmarshalJSON(data, &raw)
 	if err != nil {
 		t.Fatalf("unmarshal error: %v", err)
 	}

--- a/geojson/feature_test.go
+++ b/geojson/feature_test.go
@@ -281,6 +281,19 @@ func TestMarshalRing(t *testing.T) {
 	}
 }
 
+// uncomment to test/benchmark custom json marshalling
+// func init() {
+// 	var c = jsoniter.Config{
+// 		EscapeHTML:              true,
+// 		SortMapKeys:             false,
+// 		ValidateJsonRawMessage:  false,
+// 		MarshalFloatWith6Digits: true,
+// 	}.Froze()
+
+// 	CustomJSONMarshaler = c
+// 	CustomJSONUnmarshaler = c
+// }
+
 func BenchmarkFeatureMarshalJSON(b *testing.B) {
 	data, err := ioutil.ReadFile("../encoding/mvt/testdata/16-17896-24449.json")
 	if err != nil {
@@ -296,7 +309,7 @@ func BenchmarkFeatureMarshalJSON(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := json.Marshal(tile)
+		_, err := marshalJSON(tile)
 		if err != nil {
 			b.Fatalf("marshal error: %v", err)
 		}
@@ -313,7 +326,7 @@ func BenchmarkFeatureUnmarshalJSON(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		tile := map[string]*FeatureCollection{}
-		err = json.Unmarshal(data, &tile)
+		err = unmarshalJSON(data, &tile)
 		if err != nil {
 			b.Fatalf("could not unmarshal: %v", err)
 		}

--- a/geojson/geometry.go
+++ b/geojson/geometry.go
@@ -1,8 +1,8 @@
 package geojson
 
 import (
-	"encoding/json"
 	"errors"
+
 	"github.com/paulmach/orb"
 )
 
@@ -85,14 +85,15 @@ func (g Geometry) MarshalJSON() ([]byte, error) {
 		ng.Geometries = g.Geometries
 		ng.Type = orb.Collection{}.GeoJSONType()
 	}
-	return json.Marshal(ng)
+
+	return marshalJSON(ng)
 }
 
 // UnmarshalGeometry decodes the data into a GeoJSON feature.
 // Alternately one can call json.Unmarshal(g) directly for the same result.
 func UnmarshalGeometry(data []byte) (*Geometry, error) {
 	g := &Geometry{}
-	err := json.Unmarshal(data, g)
+	err := unmarshalJSON(data, g)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +104,7 @@ func UnmarshalGeometry(data []byte) (*Geometry, error) {
 // UnmarshalJSON will unmarshal the correct geometry from the json structure.
 func (g *Geometry) UnmarshalJSON(data []byte) error {
 	jg := &jsonGeometry{}
-	err := json.Unmarshal(data, jg)
+	err := unmarshalJSON(data, jg)
 	if err != nil {
 		return err
 	}
@@ -111,27 +112,27 @@ func (g *Geometry) UnmarshalJSON(data []byte) error {
 	switch jg.Type {
 	case "Point":
 		p := orb.Point{}
-		err = json.Unmarshal(jg.Coordinates, &p)
+		err = unmarshalJSON(jg.Coordinates, &p)
 		g.Coordinates = p
 	case "MultiPoint":
 		mp := orb.MultiPoint{}
-		err = json.Unmarshal(jg.Coordinates, &mp)
+		err = unmarshalJSON(jg.Coordinates, &mp)
 		g.Coordinates = mp
 	case "LineString":
 		ls := orb.LineString{}
-		err = json.Unmarshal(jg.Coordinates, &ls)
+		err = unmarshalJSON(jg.Coordinates, &ls)
 		g.Coordinates = ls
 	case "MultiLineString":
 		mls := orb.MultiLineString{}
-		err = json.Unmarshal(jg.Coordinates, &mls)
+		err = unmarshalJSON(jg.Coordinates, &mls)
 		g.Coordinates = mls
 	case "Polygon":
 		p := orb.Polygon{}
-		err = json.Unmarshal(jg.Coordinates, &p)
+		err = unmarshalJSON(jg.Coordinates, &p)
 		g.Coordinates = p
 	case "MultiPolygon":
 		mp := orb.MultiPolygon{}
-		err = json.Unmarshal(jg.Coordinates, &mp)
+		err = unmarshalJSON(jg.Coordinates, &mp)
 		g.Coordinates = mp
 	case "GeometryCollection":
 		g.Geometries = jg.Geometries
@@ -154,13 +155,13 @@ func (p Point) Geometry() orb.Geometry {
 
 // MarshalJSON will convert the Point into a GeoJSON Point geometry.
 func (p Point) MarshalJSON() ([]byte, error) {
-	return json.Marshal(Geometry{Coordinates: orb.Point(p)})
+	return marshalJSON(Geometry{Coordinates: orb.Point(p)})
 }
 
 // UnmarshalJSON will unmarshal the GeoJSON Point geometry.
 func (p *Point) UnmarshalJSON(data []byte) error {
 	g := &Geometry{}
-	err := json.Unmarshal(data, &g)
+	err := unmarshalJSON(data, &g)
 	if err != nil {
 		return err
 	}
@@ -184,13 +185,13 @@ func (mp MultiPoint) Geometry() orb.Geometry {
 
 // MarshalJSON will convert the MultiPoint into a GeoJSON MultiPoint geometry.
 func (mp MultiPoint) MarshalJSON() ([]byte, error) {
-	return json.Marshal(Geometry{Coordinates: orb.MultiPoint(mp)})
+	return marshalJSON(Geometry{Coordinates: orb.MultiPoint(mp)})
 }
 
 // UnmarshalJSON will unmarshal the GeoJSON MultiPoint geometry.
 func (mp *MultiPoint) UnmarshalJSON(data []byte) error {
 	g := &Geometry{}
-	err := json.Unmarshal(data, &g)
+	err := unmarshalJSON(data, &g)
 	if err != nil {
 		return err
 	}
@@ -214,13 +215,13 @@ func (ls LineString) Geometry() orb.Geometry {
 
 // MarshalJSON will convert the LineString into a GeoJSON LineString geometry.
 func (ls LineString) MarshalJSON() ([]byte, error) {
-	return json.Marshal(Geometry{Coordinates: orb.LineString(ls)})
+	return marshalJSON(Geometry{Coordinates: orb.LineString(ls)})
 }
 
 // UnmarshalJSON will unmarshal the GeoJSON MultiPoint geometry.
 func (ls *LineString) UnmarshalJSON(data []byte) error {
 	g := &Geometry{}
-	err := json.Unmarshal(data, &g)
+	err := unmarshalJSON(data, &g)
 	if err != nil {
 		return err
 	}
@@ -244,13 +245,13 @@ func (mls MultiLineString) Geometry() orb.Geometry {
 
 // MarshalJSON will convert the MultiLineString into a GeoJSON MultiLineString geometry.
 func (mls MultiLineString) MarshalJSON() ([]byte, error) {
-	return json.Marshal(Geometry{Coordinates: orb.MultiLineString(mls)})
+	return marshalJSON(Geometry{Coordinates: orb.MultiLineString(mls)})
 }
 
 // UnmarshalJSON will unmarshal the GeoJSON MultiPoint geometry.
 func (mls *MultiLineString) UnmarshalJSON(data []byte) error {
 	g := &Geometry{}
-	err := json.Unmarshal(data, &g)
+	err := unmarshalJSON(data, &g)
 	if err != nil {
 		return err
 	}
@@ -274,13 +275,13 @@ func (p Polygon) Geometry() orb.Geometry {
 
 // MarshalJSON will convert the Polygon into a GeoJSON Polygon geometry.
 func (p Polygon) MarshalJSON() ([]byte, error) {
-	return json.Marshal(Geometry{Coordinates: orb.Polygon(p)})
+	return marshalJSON(Geometry{Coordinates: orb.Polygon(p)})
 }
 
 // UnmarshalJSON will unmarshal the GeoJSON Polygon geometry.
 func (p *Polygon) UnmarshalJSON(data []byte) error {
 	g := &Geometry{}
-	err := json.Unmarshal(data, &g)
+	err := unmarshalJSON(data, &g)
 	if err != nil {
 		return err
 	}
@@ -304,13 +305,13 @@ func (mp MultiPolygon) Geometry() orb.Geometry {
 
 // MarshalJSON will convert the MultiPolygon into a GeoJSON MultiPolygon geometry.
 func (mp MultiPolygon) MarshalJSON() ([]byte, error) {
-	return json.Marshal(Geometry{Coordinates: orb.MultiPolygon(mp)})
+	return marshalJSON(Geometry{Coordinates: orb.MultiPolygon(mp)})
 }
 
 // UnmarshalJSON will unmarshal the GeoJSON MultiPolygon geometry.
 func (mp *MultiPolygon) UnmarshalJSON(data []byte) error {
 	g := &Geometry{}
-	err := json.Unmarshal(data, &g)
+	err := unmarshalJSON(data, &g)
 	if err != nil {
 		return err
 	}
@@ -334,11 +335,4 @@ type jsonGeometryMarshall struct {
 	Type        string       `json:"type"`
 	Coordinates orb.Geometry `json:"coordinates,omitempty"`
 	Geometries  []*Geometry  `json:"geometries,omitempty"`
-}
-
-type nocopyRawMessage []byte
-
-func (m *nocopyRawMessage) UnmarshalJSON(data []byte) error {
-	*m = data
-	return nil
 }

--- a/geojson/json.go
+++ b/geojson/json.go
@@ -15,9 +15,9 @@ import "encoding/json"
 //	var c = jsoniter.Config{
 //	  EscapeHTML:              true,
 //	  SortMapKeys:             false,
-//	  ValidateJsonRawMessage:  false,
 //	  MarshalFloatWith6Digits: true,
 //	}.Froze()
+//
 //	orb.CustomJSONMarshaler = c
 //	orb.CustomJSONUnmarshaler = c
 //
@@ -39,9 +39,9 @@ var CustomJSONMarshaler interface {
 //	var c = jsoniter.Config{
 //	  EscapeHTML:              true,
 //	  SortMapKeys:             false,
-//	  ValidateJsonRawMessage:  false,
 //	  MarshalFloatWith6Digits: true,
 //	}.Froze()
+//
 //	orb.CustomJSONMarshaler = c
 //	orb.CustomJSONUnmarshaler = c
 //

--- a/geojson/json.go
+++ b/geojson/json.go
@@ -1,0 +1,74 @@
+package geojson
+
+import "encoding/json"
+
+// CustomJSONMarshaler can be set to have the code use a different
+// json marshaler than the default in the standard library.
+// One use case in enabling `github.com/json-iterator/go`
+// with something like this:
+//
+//	import (
+//	  jsoniter "github.com/json-iterator/go"
+//	  "github.com/paulmach/orb"
+//	)
+//
+//	var c = jsoniter.Config{
+//	  EscapeHTML:              true,
+//	  SortMapKeys:             false,
+//	  ValidateJsonRawMessage:  false,
+//	  MarshalFloatWith6Digits: true,
+//	}.Froze()
+//	orb.CustomJSONMarshaler = c
+//	orb.CustomJSONUnmarshaler = c
+//
+// Note that any errors encountered during marshaling will be different.
+var CustomJSONMarshaler interface {
+	Marshal(v interface{}) ([]byte, error)
+} = nil
+
+// CustomJSONUnmarshaler can be set to have the code use a different
+// json unmarshaler than the default in the standard library.
+// One use case in enabling `github.com/json-iterator/go`
+// with something like this:
+//
+//	import (
+//	  jsoniter "github.com/json-iterator/go"
+//	  "github.com/paulmach/orb"
+//	)
+//
+//	var c = jsoniter.Config{
+//	  EscapeHTML:              true,
+//	  SortMapKeys:             false,
+//	  ValidateJsonRawMessage:  false,
+//	  MarshalFloatWith6Digits: true,
+//	}.Froze()
+//	orb.CustomJSONMarshaler = c
+//	orb.CustomJSONUnmarshaler = c
+//
+// Note that any errors encountered during unmarshaling will be different.
+var CustomJSONUnmarshaler interface {
+	Unmarshal(data []byte, v interface{}) error
+} = nil
+
+func marshalJSON(v interface{}) ([]byte, error) {
+	if CustomJSONMarshaler == nil {
+		return json.Marshal(v)
+	}
+
+	return CustomJSONMarshaler.Marshal(v)
+}
+
+func unmarshalJSON(data []byte, v interface{}) error {
+	if CustomJSONUnmarshaler == nil {
+		return json.Unmarshal(data, v)
+	}
+
+	return CustomJSONUnmarshaler.Unmarshal(data, v)
+}
+
+type nocopyRawMessage []byte
+
+func (m *nocopyRawMessage) UnmarshalJSON(data []byte) error {
+	*m = data
+	return nil
+}


### PR DESCRIPTION
**From the included readme changes**

If GeoJSON encoding/decoding performance is critical consider using a
third party replacement of "encoding/json" like [github.com/json-iterator/go](https://github.com/json-iterator/go)

This can be enabled with something like this:

```go
import (
  jsoniter "github.com/json-iterator/go"
  "github.com/paulmach/orb"
)

var c = jsoniter.Config{
  EscapeHTML:              true,
  SortMapKeys:             false,
  ValidateJsonRawMessage:  false,
  MarshalFloatWith6Digits: true,
}.Froze()

CustomJSONMarshaler = c
CustomJSONUnmarshaler = c
```

The above change can have dramatic performance implications, see the benchmarks below
on a 100k feature collection file:

```
benchmark                             old ns/op     new ns/op     delta
BenchmarkFeatureMarshalJSON-12        2694543       733480        -72.78%
BenchmarkFeatureUnmarshalJSON-12      5383825       2738183       -49.14%
BenchmarkGeometryMarshalJSON-12       210107        62789         -70.12%
BenchmarkGeometryUnmarshalJSON-12     691472        144689        -79.08%

benchmark                             old allocs     new allocs     delta
BenchmarkFeatureMarshalJSON-12        7818           2316           -70.38%
BenchmarkFeatureUnmarshalJSON-12      23047          31946          +38.61%
BenchmarkGeometryMarshalJSON-12       2              3              +50.00%
BenchmarkGeometryUnmarshalJSON-12     2042           18             -99.12%

benchmark                             old bytes     new bytes     delta
BenchmarkFeatureMarshalJSON-12        794088        490251        -38.26%
BenchmarkFeatureUnmarshalJSON-12      766354        1068497       +39.43%
BenchmarkGeometryMarshalJSON-12       24787         18650         -24.76%
BenchmarkGeometryUnmarshalJSON-12     79784         51374         -35.61%
```