### PR TITLE
Fixed a small twister in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ layers.Simplify(simplify.DouglasPeucker(1.0))
 layers.RemoveEmpty(1.0, 2.0)
 
 // encoding using the Mapbox Vector Tile protobuf encoding.
-data, err := layers.Marshal() // this data is NOT gzipped.
+data, err := mvt.Marshal(layers) // this data is NOT gzipped.
 
 // Sometimes MVT data is stored and transfered gzip compressed. In that case:
-data, err := layers.MarshalGzipped()
+data, err := mvt.MarshalGzipped(layers)
 ```
 
 ## Decoding WKB/EWKB from a database query

--- a/encoding/mvt/README.md
+++ b/encoding/mvt/README.md
@@ -60,10 +60,10 @@ layers.Simplify(simplify.DouglasPeucker(1.0))
 layers.RemoveEmpty(1.0, 1.0)
 
 // encoding using the Mapbox Vector Tile protobuf encoding.
-data, err := layers.Marshal() // this data is NOT gzipped.
+data, err := mvt.Marshal(layers) // this data is NOT gzipped.
 
 // Sometimes MVT data is stored and transfered gzip compressed. In that case:
-data, err := layers.MarshalGzipped()
+data, err := mvt.MarshalGzipped(layers)
 ```
 
 ## Feature IDs


### PR DESCRIPTION
Found this while copy pasting the example. 