### PR TITLE
Remove dependency on insecure crypto/md5 package

### DIFF
--- a/encoding/mvt/marshal_test.go
+++ b/encoding/mvt/marshal_test.go
@@ -1,7 +1,7 @@
 package mvt
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -546,7 +546,7 @@ func TestStableMarshalling(t *testing.T) {
 
 	for i := 0; i < 100; i++ {
 		marshal, _ := Marshal(layers)
-		checksum := md5.Sum(marshal)
+		checksum := sha256.Sum256(marshal)
 		sum := hex.EncodeToString(checksum[:])
 		values[sum] = true
 	}


### PR DESCRIPTION
`crypto/sha256` is a suitable replacement as the standard library also provides it. This change only affects test code.

To be clear, I know this pull request looks a little silly, replacing a broken hash in one test. New dependencies on `crypto/md5` have been disallowed in the codebase I'm trying to use `github.com/paulmach/orb` in. Given the change is small, easy, only affects test code, doesn't increase test runtime noticeably, and might resolve warnings about this dependency that other developers might run into, I figure I would send you a PR.