### PR TITLE
geojson: ensure geometry unmarshal errors get returned

### DIFF
--- a/geojson/example_pointer_test.go
+++ b/geojson/example_pointer_test.go
@@ -16,11 +16,11 @@ type CentroidPoint struct {
 func (cp CentroidPoint) Point() orb.Point {
 	// this is where you would decide how to define
 	// the representative point of the feature.
-	c, _ := planar.CentroidArea(cp.Feature.Geometry)
+	c, _ := planar.CentroidArea(cp.Geometry)
 	return c
 }
 
-func main() {
+func Example_centroid() {
 	qt := quadtree.New(orb.Bound{Min: orb.Point{0, 0}, Max: orb.Point{1, 1}})
 
 	// feature with center {0.5, 0.5} but centroid {0.25, 0.25}

--- a/geojson/geometry.go
+++ b/geojson/geometry.go
@@ -113,26 +113,44 @@ func (g *Geometry) UnmarshalJSON(data []byte) error {
 	case "Point":
 		p := orb.Point{}
 		err = unmarshalJSON(jg.Coordinates, &p)
+		if err != nil {
+			return err
+		}
 		g.Coordinates = p
 	case "MultiPoint":
 		mp := orb.MultiPoint{}
 		err = unmarshalJSON(jg.Coordinates, &mp)
+		if err != nil {
+			return err
+		}
 		g.Coordinates = mp
 	case "LineString":
 		ls := orb.LineString{}
 		err = unmarshalJSON(jg.Coordinates, &ls)
+		if err != nil {
+			return err
+		}
 		g.Coordinates = ls
 	case "MultiLineString":
 		mls := orb.MultiLineString{}
 		err = unmarshalJSON(jg.Coordinates, &mls)
+		if err != nil {
+			return err
+		}
 		g.Coordinates = mls
 	case "Polygon":
 		p := orb.Polygon{}
 		err = unmarshalJSON(jg.Coordinates, &p)
+		if err != nil {
+			return err
+		}
 		g.Coordinates = p
 	case "MultiPolygon":
 		mp := orb.MultiPolygon{}
 		err = unmarshalJSON(jg.Coordinates, &mp)
+		if err != nil {
+			return err
+		}
 		g.Coordinates = mp
 	case "GeometryCollection":
 		g.Geometries = jg.Geometries

--- a/geojson/geometry_test.go
+++ b/geojson/geometry_test.go
@@ -106,15 +106,15 @@ func TestGeometryUnmarshal(t *testing.T) {
 	}{
 		{
 			name: "point",
-			geom: orb.Point{},
+			geom: orb.Point{1, 2},
 		},
 		{
 			name: "multi point",
-			geom: orb.MultiPoint{},
+			geom: orb.MultiPoint{{1, 2}, {3, 4}},
 		},
 		{
 			name: "linestring",
-			geom: orb.LineString{},
+			geom: orb.LineString{{1, 2}, {3, 4}, {5, 6}},
 		},
 		{
 			name: "multi linestring",
@@ -130,7 +130,7 @@ func TestGeometryUnmarshal(t *testing.T) {
 		},
 		{
 			name: "collection",
-			geom: orb.Collection{orb.LineString{}},
+			geom: orb.Collection{orb.LineString{{1, 2}, {3, 4}}, orb.Point{5, 6}},
 		},
 	}
 
@@ -192,6 +192,47 @@ func TestGeometryUnmarshal(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "invalid geometry") {
 		t.Errorf("incorrect error: %v", err)
+	}
+}
+
+func TestGeometryUnmarshal_errors(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+	}{
+		{
+			name: "point",
+			data: `{"type":"Point","coordinates":1}`,
+		},
+		{
+			name: "multi point",
+			data: `{"type":"MultiPoint","coordinates":2}`,
+		},
+		{
+			name: "linestring",
+			data: `{"type":"LineString","coordinates":3}`,
+		},
+		{
+			name: "multi linestring",
+			data: `{"type":"MultiLineString","coordinates":4}`,
+		},
+		{
+			name: "polygon",
+			data: `{"type":"Polygon","coordinates":10.2}`,
+		},
+		{
+			name: "multi polygon",
+			data: `{"type":"MultiPolygon","coordinates":{}}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := UnmarshalGeometry([]byte(tc.data))
+			if err == nil {
+				t.Errorf("expected error, got nothing")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
turns out if you had issues with coordinates in your geojson the json error would be silently ignored.

Looks like it's been that way for a long time. https://github.com/paulmach/orb/commit/f23a70574f58f05fc956f6b2c57e1604dfde8d1c