### PR TITLE
encoding/mvt: remove use of crypto/md5 to compare marshalling in tests

### DIFF
--- a/encoding/mvt/marshal_test.go
+++ b/encoding/mvt/marshal_test.go
@@ -1,8 +1,7 @@
 package mvt
 
 import (
-	"crypto/md5"
-	"encoding/hex"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -542,17 +541,13 @@ func TestMarshal_ID(t *testing.T) {
 
 func TestStableMarshalling(t *testing.T) {
 	layers := NewLayers(loadGeoJSON(t, maptile.New(17896, 24449, 16)))
-	values := make(map[string]bool)
 
+	firstData, _ := Marshal(layers)
 	for i := 0; i < 100; i++ {
-		marshal, _ := Marshal(layers)
-		checksum := md5.Sum(marshal)
-		sum := hex.EncodeToString(checksum[:])
-		values[sum] = true
-	}
-
-	if len(values) != 1 {
-		t.Errorf("multiple values (%d) for marshalled bytes", len(values))
+		data, _ := Marshal(layers)
+		if !bytes.Equal(data, firstData) {
+			t.Errorf("a marshal had different bytes")
+		}
 	}
 }
 


### PR DESCRIPTION
In https://github.com/paulmach/orb/pull/93 we sorted property keys to make the marshalling stable. The test for this used crypto/md5 to compare the marshallings. 

@pkumar0508 mentioned the use of crypto/md5 as a problem.
> New dependencies on crypto/md5 have been disallowed in the codebase I'm trying to use github.com/paulmach/orb in.

Just removing it and doing a direct byte comparison. 