### PR TITLE
Set minimum points for a VisvalingamThreshold simplification

### DIFF
--- a/simplify/visvalingam.go
+++ b/simplify/visvalingam.go
@@ -26,7 +26,7 @@ func Visvalingam(threshold float64, minPointsToKeep int) *VisvalingamSimplifier 
 // VisvalingamThreshold runs the Visvalingam-Whyatt algorithm removing
 // triangles whose area is below the threshold.
 func VisvalingamThreshold(threshold float64) *VisvalingamSimplifier {
-	return Visvalingam(threshold, 0)
+	return Visvalingam(threshold, 3)
 }
 
 // VisvalingamKeep runs the Visvalingam-Whyatt algorithm removing

--- a/simplify/visvalingam_test.go
+++ b/simplify/visvalingam_test.go
@@ -26,8 +26,8 @@ func TestVisvalingamThreshold(t *testing.T) {
 			name:      "reduction",
 			threshold: 1.1,
 			ls:        orb.LineString{{0, 0}, {1, 1}, {0, 2}, {1, 3}, {0, 4}},
-			expected:  orb.LineString{{0, 0}, {0, 4}},
-			indexMap:  []int{0, 4},
+			expected:  orb.LineString{{0, 0}, {0, 2}, {0, 4}},
+			indexMap:  []int{0, 2, 4},
 		},
 	}
 


### PR DESCRIPTION
Currently the `VisvalingamThreshold` simplification allows polygons to be simplified to 2 points which, at 0 area, is likely not the intention of the user nor does it produce a polygon that follows the geojson standard (#45).  This changes the default to 3 points minimum.  

`Visvalingam` and `VisvalingamKeep` will still allow users to explicitly specify 0, 1, or 2 points minimum if actually desired.