### PR TITLE
Fix: InBoundMatching does not properly accept passed-in buffer

### DIFF
--- a/quadtree/quadtree.go
+++ b/quadtree/quadtree.go
@@ -299,7 +299,7 @@ func (q *Quadtree) InBoundMatching(buf []orb.Pointer, b orb.Bound, f FilterFunc)
 	}
 
 	var p []orb.Pointer
-	if len(buf) > 0 {
+	if buf != nil {
 		p = buf[:0]
 	}
 	v := &inBoundVisitor{


### PR DESCRIPTION
InBoundMatching() checks whether the length of the passed-in buffer is > 0 and if so, uses it. However, this does not properly handle the case where the passed-in buffer is allocated, i.e. cap(buf) > 0 and len(buf) == 0.