### PR TITLE
simplify: Visvalingam, by default, keeps 3 points for "areas"

### DIFF
--- a/simplify/douglas_peucker.go
+++ b/simplify/douglas_peucker.go
@@ -19,7 +19,7 @@ func DouglasPeucker(threshold float64) *DouglasPeuckerSimplifier {
 	}
 }
 
-func (s *DouglasPeuckerSimplifier) simplify(ls orb.LineString, wim bool) (orb.LineString, []int) {
+func (s *DouglasPeuckerSimplifier) simplify(ls orb.LineString, area, wim bool) (orb.LineString, []int) {
 	mask := make([]byte, len(ls))
 	mask[0] = 1
 	mask[len(mask)-1] = 1

--- a/simplify/douglas_peucker_test.go
+++ b/simplify/douglas_peucker_test.go
@@ -40,7 +40,7 @@ func TestDouglasPeucker(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			v, im := DouglasPeucker(tc.threshold).simplify(tc.ls, true)
+			v, im := DouglasPeucker(tc.threshold).simplify(tc.ls, false, true)
 			if !v.Equal(tc.expected) {
 				t.Log(v)
 				t.Log(tc.expected)

--- a/simplify/helpers.go
+++ b/simplify/helpers.go
@@ -4,7 +4,7 @@ package simplify
 import "github.com/paulmach/orb"
 
 type simplifier interface {
-	simplify(orb.LineString, bool) (orb.LineString, []int)
+	simplify(l orb.LineString, area bool, withIndexMap bool) (orb.LineString, []int)
 }
 
 func simplify(s simplifier, geom orb.Geometry) orb.Geometry {
@@ -64,24 +64,24 @@ func simplify(s simplifier, geom orb.Geometry) orb.Geometry {
 }
 
 func lineString(s simplifier, ls orb.LineString) orb.LineString {
-	return runSimplify(s, ls)
+	return runSimplify(s, ls, false)
 }
 
 func multiLineString(s simplifier, mls orb.MultiLineString) orb.MultiLineString {
 	for i := range mls {
-		mls[i] = runSimplify(s, mls[i])
+		mls[i] = runSimplify(s, mls[i], false)
 	}
 	return mls
 }
 
 func ring(s simplifier, r orb.Ring) orb.Ring {
-	return orb.Ring(runSimplify(s, orb.LineString(r)))
+	return orb.Ring(runSimplify(s, orb.LineString(r), true))
 }
 
 func polygon(s simplifier, p orb.Polygon) orb.Polygon {
 	count := 0
 	for i := range p {
-		r := orb.Ring(runSimplify(s, orb.LineString(p[i])))
+		r := orb.Ring(runSimplify(s, orb.LineString(p[i]), true))
 		if i != 0 && len(r) <= 2 {
 			continue
 		}
@@ -113,10 +113,10 @@ func collection(s simplifier, c orb.Collection) orb.Collection {
 	return c
 }
 
-func runSimplify(s simplifier, ls orb.LineString) orb.LineString {
+func runSimplify(s simplifier, ls orb.LineString, area bool) orb.LineString {
 	if len(ls) <= 2 {
 		return ls
 	}
-	ls, _ = s.simplify(ls, false)
+	ls, _ = s.simplify(ls, area, false)
 	return ls
 }

--- a/simplify/radial.go
+++ b/simplify/radial.go
@@ -20,7 +20,7 @@ func Radial(df orb.DistanceFunc, threshold float64) *RadialSimplifier {
 	}
 }
 
-func (s *RadialSimplifier) simplify(ls orb.LineString, wim bool) (orb.LineString, []int) {
+func (s *RadialSimplifier) simplify(ls orb.LineString, area, wim bool) (orb.LineString, []int) {
 	var indexMap []int
 	if wim {
 		indexMap = append(indexMap, 0)

--- a/simplify/radial_test.go
+++ b/simplify/radial_test.go
@@ -41,7 +41,7 @@ func TestRadial(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			v, im := Radial(planar.Distance, tc.threshold).simplify(tc.ls, true)
+			v, im := Radial(planar.Distance, tc.threshold).simplify(tc.ls, false, true)
 			if !v.Equal(tc.expected) {
 				t.Log(v)
 				t.Log(tc.expected)

--- a/simplify/visvalingam_test.go
+++ b/simplify/visvalingam_test.go
@@ -33,11 +33,50 @@ func TestVisvalingamThreshold(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			v, im := VisvalingamThreshold(tc.threshold).simplify(tc.ls, true)
+			v, im := VisvalingamThreshold(tc.threshold).simplify(tc.ls, false, true)
 			if !v.Equal(tc.expected) {
 				t.Log(v)
 				t.Log(tc.expected)
 				t.Errorf("incorrect line")
+			}
+
+			if !reflect.DeepEqual(im, tc.indexMap) {
+				t.Log(im)
+				t.Log(tc.indexMap)
+				t.Errorf("incorrect index map")
+			}
+		})
+	}
+}
+
+func TestVisvalingamThreshold_area(t *testing.T) {
+	cases := []struct {
+		name     string
+		r        orb.Ring
+		expected orb.Ring
+		indexMap []int
+	}{
+		{
+			name:     "reduction",
+			r:        orb.Ring{{0, 0}, {1, 0}, {1, 0.5}, {1, 1}, {0.5, 1}, {0, 1}},
+			expected: orb.Ring{{0, 0}, {1, 0}, {0, 1}},
+			indexMap: []int{0, 1, 5},
+		},
+		{
+			name:     "reduction closed",
+			r:        orb.Ring{{0, 0}, {1, 0}, {1, 0.5}, {1, 1}, {0.5, 1}, {0, 1}, {0, 0}},
+			expected: orb.Ring{{0, 0}, {1, 0}, {1, 1}, {0, 0}},
+			indexMap: []int{0, 1, 3, 6},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v, im := VisvalingamThreshold(10).simplify(orb.LineString(tc.r), true, true)
+			if !v.Equal(orb.LineString(tc.expected)) {
+				t.Log(v)
+				t.Log(tc.expected)
+				t.Errorf("incorrect ring")
 			}
 
 			if !reflect.DeepEqual(im, tc.indexMap) {
@@ -96,7 +135,7 @@ func TestVisvalingamKeep(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			v, im := VisvalingamKeep(tc.keep).simplify(tc.ls, true)
+			v, im := VisvalingamKeep(tc.keep).simplify(tc.ls, false, true)
 			if !v.Equal(tc.expected) {
 				t.Log(v)
 				t.Log(tc.expected)
@@ -181,7 +220,7 @@ func TestVisvalingam(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			v, im := Visvalingam(tc.threshold, tc.keep).simplify(tc.ls, true)
+			v, im := Visvalingam(tc.threshold, tc.keep).simplify(tc.ls, false, true)
 			if !v.Equal(tc.expected) {
 				t.Log(v)
 				t.Log(tc.expected)


### PR DESCRIPTION
As described and requested in https://github.com/paulmach/orb/pull/124 by @albertyw this PR sets the "default min points" for the Visvalingam to:
* 2 if a line, already the case
* 3 for non-closed rings, rings/polygons, etc where the first point does not match the first, i.e. implicitly closed.
* 4 for closed rings

This will give polygons completely simplified a non-zero area. This should help keep the geometry valid after simplification. Note that the simplification can still cause self-intersections.