### PR TITLE
encoding/mvt: skip encoding of features will nil geometry

### DIFF
--- a/encoding/mvt/clip.go
+++ b/encoding/mvt/clip.go
@@ -22,9 +22,18 @@ func (ls Layers) Clip(box orb.Bound) {
 }
 
 // Clip will clip all geometries in this layer to the given bounds.
+// Will remove features that clip to an empty geometry, modifies the
+// layer.Features slice in place.
 func (l *Layer) Clip(box orb.Bound) {
+	at := 0
 	for _, f := range l.Features {
 		g := clip.Geometry(box, f.Geometry)
-		f.Geometry = g
+		if g != nil {
+			f.Geometry = g
+			l.Features[at] = f
+			at++
+		}
 	}
+
+	l.Features = l.Features[:at]
 }

--- a/encoding/mvt/clip_test.go
+++ b/encoding/mvt/clip_test.go
@@ -1,10 +1,11 @@
 package mvt
 
 import (
-	"github.com/paulmach/orb"
-	"github.com/paulmach/orb/geojson"
 	"reflect"
 	"testing"
+
+	"github.com/paulmach/orb"
+	"github.com/paulmach/orb/geojson"
 )
 
 func TestLayersClip(t *testing.T) {
@@ -54,5 +55,26 @@ func TestLayersClip(t *testing.T) {
 				t.Logf("%v", tc.output)
 			}
 		})
+	}
+}
+
+func TestLayerClip_empty(t *testing.T) {
+	layer := &Layer{
+		Features: []*geojson.Feature{
+			geojson.NewFeature(orb.Polygon{{
+				{-1, 1}, {0, 1}, {1, 1}, {1, 5}, {1, -5},
+			}}),
+			geojson.NewFeature(orb.LineString{{55, 0}, {66, 0}}),
+		},
+	}
+
+	layer.Clip(orb.Bound{Min: orb.Point{50, -10}, Max: orb.Point{70, 10}})
+
+	if v := len(layer.Features); v != 1 {
+		t.Errorf("incorrect number of features: %d", v)
+	}
+
+	if v := layer.Features[0].Geometry.GeoJSONType(); v != "LineString" {
+		t.Errorf("kept the wrong geometry: %v", layer.Features[0].Geometry)
 	}
 }

--- a/encoding/mvt/marshal.go
+++ b/encoding/mvt/marshal.go
@@ -40,6 +40,7 @@ func MarshalGzipped(layers Layers) ([]byte, error) {
 }
 
 // Marshal will take a set of layers and encode them into a Mapbox Vector Tile format.
+// Features that have a nil geometry, for some reason, will be skipped and not included.
 func Marshal(layers Layers) ([]byte, error) {
 	vt := &vectortile.Tile{
 		Layers: make([]*vectortile.Tile_Layer, 0, len(layers)),
@@ -73,6 +74,10 @@ func Marshal(layers Layers) ([]byte, error) {
 }
 
 func addFeature(layer *vectortile.Tile_Layer, kve *keyValueEncoder, f *geojson.Feature) error {
+	if f.Geometry == nil {
+		return nil
+	}
+
 	if f.Geometry.GeoJSONType() == "GeometryCollection" {
 		for _, g := range f.Geometry.(orb.Collection) {
 			return addSingleGeometryFeature(layer, kve, g, f.Properties, f.ID)


### PR DESCRIPTION
Addresses an issue in https://github.com/paulmach/orb/issues/135

* will not encode features with nil geometry, used to panic
* layer.Clip() will remove the feature from the layer.Features array if it clips to nothing.

cc @polastre 