### PR TITLE
Support for Marshalling to Proto Objects

### DIFF
--- a/encoding/mvt/marshal.go
+++ b/encoding/mvt/marshal.go
@@ -41,7 +41,7 @@ func MarshalGzipped(layers Layers) ([]byte, error) {
 
 // Marshal will take a set of layers and encode them into a Mapbox Vector Tile format.
 // Features that have a nil geometry, for some reason, will be skipped and not included.
-func Marshal(layers Layers) ([]byte, error) {
+func MarshalToVectorTile(layers Layers) (*vectortile.Tile, error) {
 	vt := &vectortile.Tile{
 		Layers: make([]*vectortile.Tile_Layer, 0, len(layers)),
 	}
@@ -70,6 +70,16 @@ func Marshal(layers Layers) ([]byte, error) {
 		vt.Layers = append(vt.Layers, layer)
 	}
 
+	return vt
+}
+
+// Marshal will take a set of layers and encode them into a Mapbox Vector Tile format.
+// Features that have a nil geometry, for some reason, will be skipped and not included.
+func Marshal(layers Layers) ([]byte, error) {
+	vt, err := MarshalToVectorTile(layers)
+	if err != nil {
+		return nil, err
+	}
 	return proto.Marshal(vt)
 }
 


### PR DESCRIPTION
hi! would you be willing to support a slight refactor to marshal not just to bytes but rather to the precursor mvt spec proto objects? this is useful for grpc services which will automatically do the marshalling to bytes as part of their request handling. ive not tested this but wanted to do the PR as an illustration. let me know if its something you'd be ok supporting or not and i can write tests and clean it up if so!