### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ This tag is broken, please use v0.7.1 instead.
 
 ### Breaking Changes
 
--   tilecover now returns an error (vs. panicing) on non-closed 2d geometry by [@paulmach](https://github.com/paulmach) in https://github.com/paulmach/orb/pull/87
+-   tilecover now returns an error (vs. panicking) on non-closed 2d geometry by [@paulmach](https://github.com/paulmach) in https://github.com/paulmach/orb/pull/87
 
     This changes the signature of many of the methods in the [maptile/tilecover](https://github.com/paulmach/orb/tree/master/maptile/tilecover) package.
     To emulate the old behavior replace:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ They each provide their own README with extra info.
 -   **GeoJSON** - support as part of the [`geojson`](geojson) sub-package.
 -   **Mapbox Vector Tile** - encoding and decoding as part of the [`encoding/mvt`](encoding/mvt) sub-package.
 -   **Direct to type from DB query results** - by scanning WKB data directly into types.
--   **Rich set of sub-packages** - including [`clipping`](clip), [`simplifing`](simplify), [`quadtree`](quadtree) and more.
+-   **Rich set of sub-packages** - including [`clipping`](clip), [`simplifying`](simplify), [`quadtree`](quadtree) and more.
 
 ## Type definitions
 
@@ -142,7 +142,7 @@ layers.RemoveEmpty(1.0, 2.0)
 // encoding using the Mapbox Vector Tile protobuf encoding.
 data, err := mvt.Marshal(layers) // this data is NOT gzipped.
 
-// Sometimes MVT data is stored and transfered gzip compressed. In that case:
+// Sometimes MVT data is stored and transferred gzip compressed. In that case:
 data, err := mvt.MarshalGzipped(layers)
 ```
 

--- a/bound.go
+++ b/bound.go
@@ -156,12 +156,12 @@ func (b Bound) IsEmpty() bool {
 	return b.Min[0] > b.Max[0] || b.Min[1] > b.Max[1]
 }
 
-// IsZero return true if the bound just includes just null island.
+// IsZero return true if the bound includes just null island.
 func (b Bound) IsZero() bool {
 	return b.Max == Point{} && b.Min == Point{}
 }
 
-// Bound returns the the same bound.
+// Bound returns the same bound.
 func (b Bound) Bound() Bound {
 	return b
 }

--- a/clip/clip_test.go
+++ b/clip/clip_test.go
@@ -29,7 +29,7 @@ func TestInternalLine(t *testing.T) {
 			},
 		},
 		{
-			name:  "clips line crossign many times",
+			name:  "clips line crossing many times",
 			bound: orb.Bound{Min: orb.Point{0, 0}, Max: orb.Point{20, 20}},
 			input: orb.LineString{
 				{10, -10}, {10, 30}, {20, 30}, {20, -10},
@@ -175,7 +175,7 @@ func TestLineString(t *testing.T) {
 		output orb.MultiLineString
 	}{
 		{
-			name:  "clips line crossign many times",
+			name:  "clips line crossing many times",
 			bound: orb.Bound{Min: orb.Point{0, 0}, Max: orb.Point{20, 20}},
 			input: orb.LineString{
 				{10, -10}, {10, 30}, {20, 30}, {20, -10},
@@ -233,7 +233,7 @@ func TestLineString_OpenBound(t *testing.T) {
 		output orb.MultiLineString
 	}{
 		{
-			name:  "clips line crossign many times",
+			name:  "clips line crossing many times",
 			bound: orb.Bound{Min: orb.Point{0, 0}, Max: orb.Point{20, 20}},
 			input: orb.LineString{
 				{10, -10}, {10, 30}, {20, 30}, {20, -10},

--- a/clip/smartclip/README.md
+++ b/clip/smartclip/README.md
@@ -4,7 +4,7 @@ This package extends the clip functionality to handle partial 2d geometries. The
 rings need to only intersect the bound. The algorithm will use that, plus the orientation, to
 wrap/close the rings around the edge of the bound.
 
-The use case is [OSM multipolyon relations](https://wiki.openstreetmap.org/wiki/Relation#Multipolygon)
+The use case is [OSM multipolygon relations](https://wiki.openstreetmap.org/wiki/Relation#Multipolygon)
 where a ring (inner or outer) contains multiple ways but only one is in the current viewport.
 With only the ways intersecting the viewport and their orientation the correct shape can be drawn.
 
@@ -17,7 +17,7 @@ bound := orb.Bound{Min: orb.Point{1, 1}, Max: orb.Point{10, 10}}
 ring := orb.Ring{{0, 0}, {11, 11}}
 clipped := smartclip.Ring(bound, ring, orb.CCW)
 
-// clipped is a multipolyon with one ring that wraps counter-clockwise
+// clipped is a multipolygon with one ring that wraps counter-clockwise
 // around the top triangle of the box
 // [[[[1 1] [10 10] [5.5 10] [1 10] [1 5.5] [1 1]]]]
 ```

--- a/clip/smartclip/smart.go
+++ b/clip/smartclip/smart.go
@@ -287,7 +287,7 @@ func smartWrap(box orb.Bound, input []orb.LineString, o orb.Orientation) orb.Mul
 
 	// this operation is O(n^2). Technically we could use a linked list
 	// and remove points instead of marking them as "used".
-	// However since n is 2x the number of segements I think we're okay.
+	// However since n is 2x the number of segments I think we're okay.
 	for i := 0; i < 2*len(points); i++ {
 		ep := points[i%len(points)]
 		if ep.Used {

--- a/clip/smartclip/smart_test.go
+++ b/clip/smartclip/smart_test.go
@@ -137,7 +137,7 @@ func TestRing(t *testing.T) {
 					t.Logf("%v", expected)
 				}
 
-				// should give same result if mulipolygon
+				// should give same result if multipolygon
 				result = MultiPolygon(bound, orb.MultiPolygon{{input}}, o)
 				if !deepEqualMultiPolygon(result, expected) {
 					t.Errorf("incorrect multipolygon")
@@ -159,7 +159,7 @@ func TestPolygon(t *testing.T) {
 		expected orb.MultiPolygon
 	}{
 		{
-			name:  "with innner ring",
+			name:  "with inner ring",
 			bound: oneSix,
 			input: orb.Polygon{
 				{{0, 2}, {5, 2}, {5, 5}, {0, 5}, {0, 2}},
@@ -171,7 +171,7 @@ func TestPolygon(t *testing.T) {
 			}},
 		},
 		{
-			name:  "with innner ring that will share a side with the outer ring",
+			name:  "with inner ring that will share a side with the outer ring",
 			bound: oneSix,
 			input: orb.Polygon{
 				{{0, 2}, {3, 2}, {3, 5}, {0, 5}},
@@ -321,7 +321,7 @@ func TestPolygon(t *testing.T) {
 					t.Logf("%v", expected)
 				}
 
-				// should give same result if inputed as multi polygon
+				// should give same result if inputted as multi polygon
 				result = MultiPolygon(bound, orb.MultiPolygon{input}, o)
 				if !deepEqualMultiPolygon(result, expected) {
 					t.Errorf("incorrect multipolygon")
@@ -378,7 +378,7 @@ func TestClipMultiPolygon(t *testing.T) {
 			},
 		},
 		{
-			name:  "polygon with innner ring and single ring polygon",
+			name:  "polygon with inner ring and single ring polygon",
 			bound: orb.Bound{Min: orb.Point{1, 1}, Max: orb.Point{9, 9}},
 			input: orb.MultiPolygon{
 				{

--- a/encoding/ewkb/ewkb_test.go
+++ b/encoding/ewkb/ewkb_test.go
@@ -83,7 +83,7 @@ func compare(t testing.TB, e orb.Geometry, s int, b []byte) {
 		t.Errorf("decoder: incorrect srid: %v != %v", srid, s)
 	}
 
-	// Umarshal
+	// Unmarshal
 	g, srid, err = Unmarshal(b)
 	if err != nil {
 		t.Fatalf("unmarshal: read error: %v", err)
@@ -111,7 +111,7 @@ func compare(t testing.TB, e orb.Geometry, s int, b []byte) {
 	if !bytes.Equal(data, b) {
 		t.Logf("%v", data)
 		t.Logf("%v", b)
-		t.Errorf("marshal: incorrent encoding")
+		t.Errorf("marshal: incorrect encoding")
 	}
 
 	// Encode
@@ -132,7 +132,7 @@ func compare(t testing.TB, e orb.Geometry, s int, b []byte) {
 	if !bytes.Equal(data, buf.Bytes()) {
 		t.Logf("%v", data)
 		t.Logf("%v", b)
-		t.Errorf("encode: incorrent encoding")
+		t.Errorf("encode: incorrect encoding")
 	}
 
 	// pass in srid
@@ -146,7 +146,7 @@ func compare(t testing.TB, e orb.Geometry, s int, b []byte) {
 	if !bytes.Equal(data, buf.Bytes()) {
 		t.Logf("%v", data)
 		t.Logf("%v", b)
-		t.Errorf("encode with srid: incorrent encoding")
+		t.Errorf("encode with srid: incorrect encoding")
 	}
 
 	// preallocation

--- a/encoding/ewkb/scanner_test.go
+++ b/encoding/ewkb/scanner_test.go
@@ -1184,7 +1184,7 @@ func TestScanBound_errors(t *testing.T) {
 }
 
 func TestValue(t *testing.T) {
-	t.Run("marshalls geometry", func(t *testing.T) {
+	t.Run("marshals geometry", func(t *testing.T) {
 		testPoint := orb.Point{1, 2}
 		testPointData := MustMarshal(testPoint, 4326)
 		val, err := Value(testPoint, 4326).Value()

--- a/encoding/internal/wkbcommon/wkb.go
+++ b/encoding/internal/wkbcommon/wkb.go
@@ -30,7 +30,7 @@ const (
 
 const (
 	// limits so that bad data can't come in and preallocate tons of memory.
-	// Well formed data with less elements will allocate the correct amount just fine.
+	// Well formed data with fewer elements will allocate the correct amount just fine.
 	MaxPointsAlloc = 10000
 	MaxMultiAlloc  = 100
 )

--- a/encoding/internal/wkbcommon/wkb_test.go
+++ b/encoding/internal/wkbcommon/wkb_test.go
@@ -40,7 +40,7 @@ func compare(t testing.TB, e orb.Geometry, s int, b []byte) {
 		t.Errorf("decoder: incorrect srid: %v != %v", srid, s)
 	}
 
-	// Umarshal
+	// Unmarshal
 	g, srid, err = Unmarshal(b)
 	if err != nil {
 		t.Fatalf("unmarshal: read error: %v", err)
@@ -67,7 +67,7 @@ func compare(t testing.TB, e orb.Geometry, s int, b []byte) {
 	if !bytes.Equal(data, b) {
 		t.Logf("%v", data)
 		t.Logf("%v", b)
-		t.Errorf("marshal: incorrent encoding")
+		t.Errorf("marshal: incorrect encoding")
 	}
 
 	// preallocation

--- a/encoding/mvt/README.md
+++ b/encoding/mvt/README.md
@@ -62,7 +62,7 @@ layers.RemoveEmpty(1.0, 1.0)
 // encoding using the Mapbox Vector Tile protobuf encoding.
 data, err := mvt.Marshal(layers) // this data is NOT gzipped.
 
-// Sometimes MVT data is stored and transfered gzip compressed. In that case:
+// Sometimes MVT data is stored and transferred gzip compressed. In that case:
 data, err := mvt.MarshalGzipped(layers)
 ```
 

--- a/encoding/mvt/marshal_test.go
+++ b/encoding/mvt/marshal_test.go
@@ -131,7 +131,7 @@ func TestMarshalUnmarshalForGeometryCollection(t *testing.T) {
 	// compare geometry
 	xe, ye := tileEpsilon(tile)
 	if len(results) == len(expected) {
-		t.Errorf("result geometry count must be splited polygon: %v (but result is %v)", len(results), len(expected))
+		t.Errorf("result geometry count must be split polygon: %v (but result is %v)", len(results), len(expected))
 	}
 	for i, result := range results {
 		compareOrbGeometry(t, result.Geometry, expected[i], xe, ye)

--- a/encoding/mvt/simplify.go
+++ b/encoding/mvt/simplify.go
@@ -5,7 +5,7 @@ import (
 	"github.com/paulmach/orb/planar"
 )
 
-// Simplify will run all the geometry of all the layers through the provided simplifer.
+// Simplify will run all the geometry of all the layers through the provided simplifier.
 func (ls Layers) Simplify(s orb.Simplifier) {
 	for _, l := range ls {
 		l.Simplify(s)

--- a/encoding/wkb/scanner_test.go
+++ b/encoding/wkb/scanner_test.go
@@ -993,7 +993,7 @@ func TestScanBound_errors(t *testing.T) {
 }
 
 func TestValue(t *testing.T) {
-	t.Run("marshalls geometry", func(t *testing.T) {
+	t.Run("marshals geometry", func(t *testing.T) {
 		val, err := Value(testPoint).Value()
 		if err != nil {
 			t.Errorf("value error: %v", err)

--- a/encoding/wkb/wkb.go
+++ b/encoding/wkb/wkb.go
@@ -1,5 +1,5 @@
 // Package wkb is for decoding ESRI's Well Known Binary (WKB) format
-// sepcification at https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary
+// specification at https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary
 package wkb
 
 import (

--- a/encoding/wkb/wkb_test.go
+++ b/encoding/wkb/wkb_test.go
@@ -69,7 +69,7 @@ func compare(t testing.TB, e orb.Geometry, b []byte) {
 		t.Errorf("decoder: incorrect geometry: %v != %v", g, e)
 	}
 
-	// Umarshal
+	// Unmarshal
 	g, err = Unmarshal(b)
 	if err != nil {
 		t.Fatalf("unmarshal: read error: %v", err)
@@ -92,7 +92,7 @@ func compare(t testing.TB, e orb.Geometry, b []byte) {
 	if !bytes.Equal(data, b) {
 		t.Logf("%v", data)
 		t.Logf("%v", b)
-		t.Errorf("marshal: incorrent encoding")
+		t.Errorf("marshal: incorrect encoding")
 	}
 
 	// preallocation

--- a/encoding/wkt/unmarshal.go
+++ b/encoding/wkt/unmarshal.go
@@ -51,7 +51,7 @@ func unmarshalPoint(s string) (orb.Point, error) {
 	return tp, nil
 }
 
-// parsePoint pase point by (x y)
+// parsePoint parse point by (x y)
 func parsePoint(s string) (p orb.Point, err error) {
 	one, two, ok := cut(s, " ")
 	if !ok {
@@ -493,7 +493,7 @@ func splitByRegexpYield(s string, re *regexp.Regexp, set func(int), yield func(s
 // We use a yield function because it was faster/used less memory than
 // allocating an array of the results.
 func splitOnComma(s string, yield func(s string) error) error {
-	// in WKT points are separtated by commas, coordinates in points are separted by spaces
+	// in WKT points are separated by commas, coordinates in points are separated by spaces
 	// e.g. 1 2,3 4,5 6,7 81 2,5 4
 	// we want to split this and find each point.
 
@@ -587,7 +587,7 @@ func trimSpace(s string) string {
 }
 
 // gets the ToUpper case of the first 20 chars.
-// This is to determin the type without doing a full strings.ToUpper
+// This is to determine the type without doing a full strings.ToUpper
 func upperPrefix(s string) []byte {
 	prefix := make([]byte, 20)
 	for i := 0; i < 20 && i < len(s); i++ {
@@ -601,7 +601,7 @@ func upperPrefix(s string) []byte {
 	return prefix
 }
 
-// coppied here from strings.Cut so we don't require go1.18
+// copied here from strings.Cut so we don't require go1.18
 func cut(s, sep string) (before, after string, found bool) {
 	if i := strings.Index(s, sep); i >= 0 {
 		return s[:i], s[i+len(sep):], true

--- a/equal.go
+++ b/equal.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-// Equal returns if the two geometrires are equal.
+// Equal returns if the two geometries are equal.
 func Equal(g1, g2 Geometry) bool {
 	if g1 == nil || g2 == nil {
 		return g1 == g2

--- a/geo/area_test.go
+++ b/geo/area_test.go
@@ -60,7 +60,7 @@ func TestSignedArea(t *testing.T) {
 				t.Errorf("wrong area: %v != %v", val, tc.result)
 			}
 
-			// should work without redudant last point.
+			// should work without redundant last point.
 			if tc.ring[0] == tc.ring[len(tc.ring)-1] {
 				tc.ring = tc.ring[:len(tc.ring)-1]
 				val = SignedArea(tc.ring)

--- a/geo/bound.go
+++ b/geo/bound.go
@@ -79,13 +79,13 @@ func BoundWidth(b orb.Bound) float64 {
 //MinLatitude is the minimum possible latitude
 var minLatitude = deg2rad(-90)
 
-//MaxLatitude is the maxiumum possible latitude
+//MaxLatitude is the maximum possible latitude
 var maxLatitude = deg2rad(90)
 
 //MinLongitude is the minimum possible longitude
 var minLongitude = deg2rad(-180)
 
-//MaxLongitude is the maxiumum possible longitude
+//MaxLongitude is the maximum possible longitude
 var maxLongitude = deg2rad(180)
 
 func deg2rad(d float64) float64 {

--- a/geojson/example_test.go
+++ b/geojson/example_test.go
@@ -59,7 +59,7 @@ func ExampleFeatureCollection_foreignMembers() {
 	// {"features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[102,0.5]},"properties":{"prop0":"value0"}}],"title":"Title as Foreign Member","type":"FeatureCollection"}
 }
 
-// MyFeatureCollection is a depricated/no longer supported way to extract
+// MyFeatureCollection is a deprecated/no longer supported way to extract
 // foreign/extra members from a feature collection. Now an UnmarshalJSON
 // method, like below, is required for it to work.
 type MyFeatureCollection struct {

--- a/geojson/geometry.go
+++ b/geojson/geometry.go
@@ -8,7 +8,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 )
 
-// ErrInvalidGeometry will be returned if a the json of the geometry is invalid.
+// ErrInvalidGeometry will be returned if the json of the geometry is invalid.
 var ErrInvalidGeometry = errors.New("geojson: invalid geometry")
 
 // A Geometry matches the structure of a GeoJSON Geometry.
@@ -19,7 +19,7 @@ type Geometry struct {
 }
 
 // NewGeometry will create a Geometry object but will convert
-// the input into a GoeJSON geometry. For example, it will convert
+// the input into a GeoJSON geometry. For example, it will convert
 // Rings and Bounds into Polygons.
 func NewGeometry(g orb.Geometry) *Geometry {
 	jg := &Geometry{}
@@ -44,7 +44,7 @@ func NewGeometry(g orb.Geometry) *Geometry {
 }
 
 // Geometry returns the orb.Geometry for the geojson Geometry.
-// This will convert the "Geometries" into a orb.Collection if applicable.
+// This will convert the "Geometries" into an orb.Collection if applicable.
 func (g *Geometry) Geometry() orb.Geometry {
 	if g.Coordinates != nil {
 		return g.Coordinates

--- a/geojson/geometry_test.go
+++ b/geojson/geometry_test.go
@@ -362,7 +362,7 @@ func TestHelperTypes(t *testing.T) {
 			}
 
 			// not the correct type should return error.
-			// non of they types directly supported are geometry collections.
+			// none of the types directly supported are geometry collections.
 			data, err = json.Marshal(NewGeometry(orb.Collection{orb.Point{}}))
 			if err != nil {
 				t.Errorf("unmarshal error: %v", err)
@@ -417,7 +417,7 @@ func TestHelperTypes(t *testing.T) {
 			}
 
 			// not the correct type should return error.
-			// non of they types directly supported are geometry collections.
+			// none of the types directly supported are geometry collections.
 			data, err = bson.Marshal(NewGeometry(orb.Collection{orb.Point{}}))
 			if err != nil {
 				t.Errorf("unmarshal error: %v", err)

--- a/maptile/tilecover/README.md
+++ b/maptile/tilecover/README.md
@@ -1,7 +1,7 @@
 # orb/maptile/tilecover [![Godoc Reference](https://pkg.go.dev/badge/github.com/paulmach/orb)](https://pkg.go.dev/github.com/paulmach/orb/maptile/tilecover)
 
 Package `tilecover` computes the covering set of tiles for an `orb.Geometry`.
-It is a a port of the nodejs library [tile-cover](https://github.com/mapbox/tile-cover)
+It is a port of the nodejs library [tile-cover](https://github.com/mapbox/tile-cover)
 which is a port from Google's S2 library. The same set of tests pass.
 
 ## Usage

--- a/maptile/tilecover/merge.go
+++ b/maptile/tilecover/merge.go
@@ -3,7 +3,7 @@ package tilecover
 import "github.com/paulmach/orb/maptile"
 
 // MergeUp will merge up the tiles in a given set up to the
-// the give min zoom. Tiles will be merged up only if all 4 siblings
+// given min zoom. Tiles will be merged up only if all 4 siblings
 // are in the set. The tiles in the input set are expected
 // to all be of the same zoom, e.g. outputs of the Geometry function.
 func MergeUp(set maptile.Set, min maptile.Zoom) maptile.Set {
@@ -77,7 +77,7 @@ func MergeUp(set maptile.Set, min maptile.Zoom) maptile.Set {
 }
 
 // MergeUpPartial will merge up the tiles in a given set up to the
-// the give min zoom. Tiles will be merged up if `count` siblings are in the
+// given min zoom. Tiles will be merged up if `count` siblings are in the
 // set. The tiles in the input set are expected to all be of the same
 // zoom, e.g. outputs of the Geometry function.
 func MergeUpPartial(set maptile.Set, min maptile.Zoom, count int) maptile.Set {

--- a/maptile/tilecover/polygon.go
+++ b/maptile/tilecover/polygon.go
@@ -58,7 +58,7 @@ func polygon(set maptile.Set, p orb.Polygon, zoom maptile.Zoom) error {
 			ni := (i + 1) % len(ring)
 			y := ring[i][1]
 
-			// add interesction if it's not local extremum or duplicate
+			// add intersection if it's not local extremum or duplicate
 			if (ring[pi][1] < y || ring[ni][1] < y) && // not local minimum
 				(y < ring[pi][1] || y < ring[ni][1]) && // not local maximum
 				y != ring[ni][1] {

--- a/multi_point.go
+++ b/multi_point.go
@@ -1,6 +1,6 @@
 package orb
 
-// A MultiPoint represents a set of points in the 2D Eucledian or Cartesian plane.
+// A MultiPoint represents a set of points in the 2D Euclidean or Cartesian plane.
 type MultiPoint []Point
 
 // GeoJSONType returns the GeoJSON type for the object.

--- a/planar/area.go
+++ b/planar/area.go
@@ -18,8 +18,8 @@ func Area(g orb.Geometry) float64 {
 
 // CentroidArea returns both the centroid and the area in the 2d plane.
 // Since the area is need for the centroid, return both.
-// Polygon area will always be >= zero. Ring area my be negative if it has
-// a clockwise winding orider.
+// Polygon area will always be >= zero. Ring area may be negative if it has
+// a clockwise winding order.
 func CentroidArea(g orb.Geometry) (orb.Point, float64) {
 	if g == nil {
 		return orb.Point{}, 0

--- a/planar/area_test.go
+++ b/planar/area_test.go
@@ -117,7 +117,7 @@ func TestCentroid_Ring(t *testing.T) {
 			result: orb.Point{0.5, 0.5},
 		},
 		{
-			name:   "redudent points",
+			name:   "redundant points",
 			ring:   orb.Ring{{0, 0}, {1, 0}, {2, 0}, {1, 3}, {0, 0}},
 			result: orb.Point{1, 1},
 		},
@@ -205,7 +205,7 @@ func TestArea_Ring(t *testing.T) {
 				t.Errorf("wrong area: %v != %v", val, tc.result)
 			}
 
-			// check that are rendant last point is implicit
+			// check that are redundant last point is implicit
 			tc.ring = tc.ring[:len(tc.ring)-1]
 			_, val = CentroidArea(tc.ring)
 			if val != tc.result {

--- a/planar/contains_test.go
+++ b/planar/contains_test.go
@@ -103,7 +103,7 @@ func TestRingContains(t *testing.T) {
 		}
 	}
 
-	// colinear with segments but outside
+	// collinear with segments but outside
 	for i := 1; i < len(ring); i++ {
 		p := interpolate(ring[i], ring[i-1], 5)
 		if RingContains(ring, p) {

--- a/planar/distance_from.go
+++ b/planar/distance_from.go
@@ -12,7 +12,7 @@ func DistanceFromSegment(a, b, point orb.Point) float64 {
 	return math.Sqrt(DistanceFromSegmentSquared(a, b, point))
 }
 
-// DistanceFromSegmentSquared returns point's squared distance from the segement [a, b].
+// DistanceFromSegmentSquared returns point's squared distance from the segment [a, b].
 func DistanceFromSegmentSquared(a, b, point orb.Point) float64 {
 	x := a[0]
 	y := a[1]

--- a/project/helpers.go
+++ b/project/helpers.go
@@ -4,7 +4,7 @@ package project
 
 import "github.com/paulmach/orb"
 
-// Geometry is a helper to project any geomtry.
+// Geometry is a helper to project any geometry.
 func Geometry(g orb.Geometry, proj orb.Projection) orb.Geometry {
 	if g == nil {
 		return nil
@@ -34,7 +34,7 @@ func Geometry(g orb.Geometry, proj orb.Projection) orb.Geometry {
 	panic("geometry type not supported")
 }
 
-// Point is a helper to project an a point
+// Point is a helper to project a point
 func Point(p orb.Point, proj orb.Projection) orb.Point {
 	return proj(p)
 }

--- a/quadtree/quadtree.go
+++ b/quadtree/quadtree.go
@@ -158,7 +158,7 @@ func (q *Quadtree) Remove(p orb.Pointer, eq FilterFunc) bool {
 }
 
 // removeNode is the recursive fixing up of the tree when we remove a node.
-// It will pull up a child value into it's place. It will try to remove leaf nodes
+// It will pull up a child value into its place. It will try to remove leaf nodes
 // that are now empty, since their values got pulled up.
 func removeNode(n *node) bool {
 	i := -1

--- a/quadtree/quadtree_test.go
+++ b/quadtree/quadtree_test.go
@@ -227,12 +227,12 @@ func TestQuadtreeRemoveAndAdd_sameLoc(t *testing.T) {
 		t.Error("didn't find/remove point")
 	}
 
-	// 5 is a tail point, so its not does not actually get removed
+	// 5 is a tail point, so it does not actually get removed
 	if c := countNodes(qt.root); c != 2 {
 		t.Errorf("incorrect number of nodes: %v != 2", c)
 	}
 
-	// add a 3th point again
+	// add a 3rd point again
 	err = qt.Add(p3)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -407,7 +407,7 @@ func TestQuadtreeMatching(t *testing.T) {
 		expected orb.Pointer
 	}{
 		{
-			name:     "no filtred",
+			name:     "no filters",
 			point:    orb.Point{0.1, 0.1},
 			expected: orb.Point{0, 0},
 		},

--- a/ring.go
+++ b/ring.go
@@ -31,7 +31,7 @@ func (r Ring) Bound() Bound {
 	return MultiPoint(r).Bound()
 }
 
-// Orientation returns 1 if the the ring is in couter-clockwise order,
+// Orientation returns 1 if the ring is in counter-clockwise order,
 // return -1 if the ring is the clockwise order and 0 if the ring is
 // degenerate and had no area.
 func (r Ring) Orientation() Orientation {

--- a/ring_test.go
+++ b/ring_test.go
@@ -76,7 +76,7 @@ func TestRing_Orientation(t *testing.T) {
 				t.Errorf("wrong orientation: %v != %v", val, tc.result)
 			}
 
-			// should work without redudant last point.
+			// should work without redundant last point.
 			ring := tc.ring[:len(tc.ring)-1]
 			val = ring.Orientation()
 			if val != tc.result {

--- a/simplify/README.md
+++ b/simplify/README.md
@@ -1,6 +1,6 @@
 # orb/simplify [![Godoc Reference](https://pkg.go.dev/badge/github.com/paulmach/orb)](https://pkg.go.dev/github.com/paulmach/orb/simplify)
 
-This package implements several reducing/simplifing function for `orb.Geometry` types.
+This package implements several reducing/simplifying function for `orb.Geometry` types.
 
 Currently implemented:
 

--- a/simplify/benchmarks_test.go
+++ b/simplify/benchmarks_test.go
@@ -88,7 +88,7 @@ func BenchmarkRadial(b *testing.B) {
 	}
 }
 
-func BenchmarkRadial_DisanceSquared(b *testing.B) {
+func BenchmarkRadial_DistanceSquared(b *testing.B) {
 	ls := benchmarkData()
 
 	var data []orb.LineString

--- a/simplify/example_test.go
+++ b/simplify/example_test.go
@@ -18,7 +18,7 @@ func ExampleDouglasPeuckerSimplifier() {
 	//  +-----+
 	original := orb.LineString{{0, 0}, {2, 0}, {1, 1}, {0, 2}}
 
-	// low threshold just removes the colinear point
+	// low threshold just removes the collinear point
 	reduced := simplify.DouglasPeucker(0.0).Simplify(original.Clone())
 	fmt.Println(reduced)
 

--- a/simplify/visvalingam.go
+++ b/simplify/visvalingam.go
@@ -9,7 +9,7 @@ import (
 var _ orb.Simplifier = &VisvalingamSimplifier{}
 
 // A VisvalingamSimplifier is a reducer that
-// performs the vivalingham algorithm.
+// performs the visvalingham algorithm.
 type VisvalingamSimplifier struct {
 	Threshold float64
 

--- a/simplify/visvalingam_test.go
+++ b/simplify/visvalingam_test.go
@@ -209,7 +209,7 @@ func TestVisvalingam(t *testing.T) {
 			indexMap:  []int{0, 2, 4},
 		},
 		{
-			name:      "removes colinear points",
+			name:      "removes collinear points",
 			threshold: 0.1,
 			keep:      0,
 			ls:        orb.LineString{{0, 0}, {0, 1}, {0, 2}},


### PR DESCRIPTION
Fixed a bunch of typos, mostly in code comments and readme docs.

FYI, the most common words:
* incorrent (5)
* umarshal (3)
* colinear (3)
* crossign (3)
* innner (3)
* marshalls (2)
* maxiumum (2)
* multipolyon (2)
* redudant (2)
* simplifing (2)
* transfered (2)