### PR TITLE
Fix panic on reverse of empty linestrings

### DIFF
--- a/line_string.go
+++ b/line_string.go
@@ -17,6 +17,11 @@ func (ls LineString) Dimensions() int {
 // This is done inplace, ie. it modifies the original data.
 func (ls LineString) Reverse() {
 	l := len(ls) - 1
+
+	if l < 1 {
+		return
+	}
+
 	for i := 0; i <= l/2; i++ {
 		ls[i], ls[l-i] = ls[l-i], ls[i]
 	}

--- a/line_string_test.go
+++ b/line_string_test.go
@@ -21,6 +21,16 @@ func TestLineStringReverse(t *testing.T) {
 		output LineString
 	}{
 		{
+			name:   "0 point line",
+			input:  LineString{},
+			output: LineString{},
+		},
+		{
+			name:   "1 point line",
+			input:  LineString{{1, 2}},
+			output: LineString{{1, 2}},
+		},
+		{
 			name:   "2 point line",
 			input:  LineString{{1, 2}, {3, 4}},
 			output: LineString{{3, 4}, {1, 2}},


### PR DESCRIPTION
Calling reverse() on an empty LineString causes a panic.
This PR handles this case and also adds it to the corresponding unit test.



The program was tested solely for our own use cases, which might differ from yours.

Jochen Mehlhorn <jochen.mehlhorn@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH

[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)