### PR TITLE
geojson: handle extra/foreign members in feature

### DIFF
--- a/geojson/README.md
+++ b/geojson/README.md
@@ -47,7 +47,7 @@ rawJSON, _ := fc.MarshalJSON()
 blob, _ := json.Marshal(fc)
 ```
 
-## Foreign/extra members in a feature collection
+## Foreign/extra members in feature and feature collection
 
 ```go
 rawJSON := []byte(`

--- a/geojson/feature.go
+++ b/geojson/feature.go
@@ -15,6 +15,12 @@ type Feature struct {
 	BBox       BBox         `json:"bbox,omitempty"`
 	Geometry   orb.Geometry `json:"geometry"`
 	Properties Properties   `json:"properties"`
+
+	// ExtraMembers can be used to encoded/decode extra key/members in
+	// the base of the feature object. Note that keys of "id", "type", "bbox"
+	// "geometry" and "properties" will not work as those are reserved by the
+	// GeoJSON spec.
+	ExtraMembers Properties `json:"-"`
 }
 
 // NewFeature creates and initializes a GeoJSON feature given the required attributes.
@@ -38,6 +44,8 @@ var _ orb.Pointer = &Feature{}
 // MarshalJSON converts the feature object into the proper JSON.
 // It will handle the encoding of all the child geometries.
 // Alternately one can call json.Marshal(f) directly for the same result.
+// Items in the ExtraMembers map will be included in the base of the
+// feature object.
 func (f Feature) MarshalJSON() ([]byte, error) {
 	return marshalJSON(newFeatureDoc(&f))
 }
@@ -45,24 +53,56 @@ func (f Feature) MarshalJSON() ([]byte, error) {
 // MarshalBSON converts the feature object into the proper JSON.
 // It will handle the encoding of all the child geometries.
 // Alternately one can call json.Marshal(f) directly for the same result.
+// Items in the ExtraMembers map will be included in the base of the
+// feature object.
 func (f Feature) MarshalBSON() ([]byte, error) {
 	return bson.Marshal(newFeatureDoc(&f))
 }
 
-func newFeatureDoc(f *Feature) *featureDoc {
-	doc := &featureDoc{
-		ID:         f.ID,
-		Type:       "Feature",
-		Properties: f.Properties,
-		BBox:       f.BBox,
-		Geometry:   NewGeometry(f.Geometry),
+func newFeatureDoc(f *Feature) interface{} {
+	if len(f.ExtraMembers) == 0 {
+		doc := &featureDoc{
+			ID:         f.ID,
+			Type:       "Feature",
+			Properties: f.Properties,
+			BBox:       f.BBox,
+			Geometry:   NewGeometry(f.Geometry),
+		}
+
+		if len(doc.Properties) == 0 {
+			doc.Properties = nil
+		}
+
+		return doc
 	}
 
-	if len(doc.Properties) == 0 {
-		doc.Properties = nil
+	var tmp map[string]interface{}
+	if f.ExtraMembers != nil {
+		tmp = f.ExtraMembers.Clone()
+	} else {
+		tmp = make(map[string]interface{}, 3)
 	}
 
-	return doc
+	delete(tmp, "id")
+	if f.ID != nil {
+		tmp["id"] = f.ID
+	}
+	tmp["type"] = "Feature"
+
+	delete(tmp, "bbox")
+	if f.BBox != nil {
+		tmp["bbox"] = f.BBox
+	}
+
+	tmp["geometry"] = NewGeometry(f.Geometry)
+
+	if len(f.Properties) == 0 {
+		tmp["properties"] = nil
+	} else {
+		tmp["properties"] = f.Properties
+	}
+
+	return tmp
 }
 
 // UnmarshalFeature decodes the data into a GeoJSON feature.
@@ -85,45 +125,122 @@ func (f *Feature) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	doc := &featureDoc{}
-	err := unmarshalJSON(data, &doc)
+	tmp := make(map[string]nocopyRawMessage, 4)
+
+	err := unmarshalJSON(data, &tmp)
 	if err != nil {
 		return err
 	}
 
-	return featureUnmarshalFinish(doc, f)
+	*f = Feature{}
+	for key, value := range tmp {
+		switch key {
+		case "id":
+			err := unmarshalJSON(value, &f.ID)
+			if err != nil {
+				return err
+			}
+		case "type":
+			err := unmarshalJSON(value, &f.Type)
+			if err != nil {
+				return err
+			}
+		case "bbox":
+			err := unmarshalJSON(value, &f.BBox)
+			if err != nil {
+				return err
+			}
+		case "geometry":
+			g := &Geometry{}
+			err := unmarshalJSON(value, &g)
+			if err != nil {
+				return err
+			}
+
+			if g != nil {
+				f.Geometry = g.Geometry()
+			}
+		case "properties":
+			err := unmarshalJSON(value, &f.Properties)
+			if err != nil {
+				return err
+			}
+		default:
+			if f.ExtraMembers == nil {
+				f.ExtraMembers = Properties{}
+			}
+
+			var val interface{}
+			err := unmarshalJSON(value, &val)
+			if err != nil {
+				return err
+			}
+			f.ExtraMembers[key] = val
+		}
+	}
+
+	if f.Type != "Feature" {
+		return fmt.Errorf("geojson: not a feature: type=%s", f.Type)
+	}
+
+	return nil
 }
 
 // UnmarshalBSON will unmarshal a BSON document created with bson.Marshal.
 func (f *Feature) UnmarshalBSON(data []byte) error {
-	doc := &featureDoc{}
-	err := bson.Unmarshal(data, &doc)
+	tmp := make(map[string]bson.RawValue, 4)
+
+	err := bson.Unmarshal(data, &tmp)
 	if err != nil {
 		return err
 	}
 
-	return featureUnmarshalFinish(doc, f)
-}
+	*f = Feature{}
+	for key, value := range tmp {
+		switch key {
+		case "id":
+			err := value.Unmarshal(&f.ID)
+			if err != nil {
+				return err
+			}
+		case "type":
+			f.Type, _ = bson.RawValue(value).StringValueOK()
+		case "bbox":
+			err := value.Unmarshal(&f.BBox)
+			if err != nil {
+				return err
+			}
+		case "geometry":
+			g := &Geometry{}
+			err := value.Unmarshal(&g)
+			if err != nil {
+				return err
+			}
 
-func featureUnmarshalFinish(doc *featureDoc, f *Feature) error {
-	if doc.Type != "Feature" {
-		return fmt.Errorf("geojson: not a feature: type=%s", doc.Type)
-	}
+			if g != nil {
+				f.Geometry = g.Geometry()
+			}
+		case "properties":
+			err := value.Unmarshal(&f.Properties)
+			if err != nil {
+				return err
+			}
+		default:
+			if f.ExtraMembers == nil {
+				f.ExtraMembers = Properties{}
+			}
 
-	var g orb.Geometry
-	if doc.Geometry != nil {
-		if doc.Geometry.Coordinates == nil && doc.Geometry.Geometries == nil {
-			return ErrInvalidGeometry
+			var val interface{}
+			err := value.Unmarshal(&val)
+			if err != nil {
+				return err
+			}
+			f.ExtraMembers[key] = val
 		}
-		g = doc.Geometry.Geometry()
 	}
 
-	*f = Feature{
-		ID:         doc.ID,
-		Type:       doc.Type,
-		Properties: doc.Properties,
-		BBox:       doc.BBox,
-		Geometry:   g,
+	if f.Type != "Feature" {
+		return fmt.Errorf("geojson: not a feature: type=%s", f.Type)
 	}
 
 	return nil


### PR DESCRIPTION
https://github.com/paulmach/orb/pull/56 added support for ExtraMembers to feature collections, this PR adds it for features. I'm not sure if this technically allowed by the spec, but if people want to do it, now they can.

See https://github.com/paulmach/orb/pull/56 for more info about why this is necessary and how it works. 

This was requested in this issue https://github.com/paulmach/orb/issues/146