### PR TITLE
encoding/wkt: preserve EMPTY members when unmarshalling a collection

### DIFF
--- a/encoding/wkt/collection_empty_test.go
+++ b/encoding/wkt/collection_empty_test.go
@@ -1,0 +1,140 @@
+package wkt
+
+import (
+	"testing"
+
+	"github.com/paulmach/orb"
+)
+
+// TestUnmarshalCollection_roundTrip checks the self-oracle: whatever Marshal
+// emits for a GEOMETRYCOLLECTION, Unmarshal must read back to an equal value.
+// EMPTY members have no parentheses, which the member splitter used to drop.
+func TestUnmarshalCollection_roundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		gc   orb.Collection
+	}{
+		// each empty-capable geometry type as an EMPTY sole member
+		{"linestring empty", orb.Collection{orb.LineString{}}},
+		{"polygon empty", orb.Collection{orb.Polygon{}}},
+		{"multipoint empty", orb.Collection{orb.MultiPoint{}}},
+		{"multilinestring empty", orb.Collection{orb.MultiLineString{}}},
+		{"multipolygon empty", orb.Collection{orb.MultiPolygon{}}},
+		{"collection empty", orb.Collection{orb.Collection{}}},
+
+		// mixed empty and non-empty members, in both orders
+		{"non-empty then empty", orb.Collection{
+			orb.Point{1, 2}, orb.LineString{},
+		}},
+		{"empty then non-empty", orb.Collection{
+			orb.LineString{}, orb.Point{1, 2},
+		}},
+		{"several empties between non-empties", orb.Collection{
+			orb.Point{1, 2}, orb.Polygon{}, orb.MultiPoint{},
+			orb.LineString{{3, 4}, {5, 6}},
+		}},
+
+		// nested collections carrying empty members
+		{"nested collection with empty", orb.Collection{
+			orb.Collection{orb.LineString{}},
+			orb.Point{7, 8},
+		}},
+
+		// pure non-empty members (regression: must stay unchanged)
+		{"non-empty only", orb.Collection{
+			orb.Point{1, 2},
+			orb.LineString{{3, 4}, {5, 6}},
+			orb.Polygon{{{0, 0}, {1, 0}, {1, 1}, {0, 0}}},
+		}},
+		{"nested non-empty", orb.Collection{
+			orb.Collection{orb.Point{1, 2}, orb.LineString{{3, 4}, {5, 6}}},
+			orb.MultiPolygon{{{{1, 2}, {3, 4}}}},
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := MarshalString(tc.gc)
+
+			got, err := Unmarshal(s)
+			if err != nil {
+				t.Fatalf("own output %q rejected by Unmarshal: %v", s, err)
+			}
+
+			gc, ok := got.(orb.Collection)
+			if !ok {
+				t.Fatalf("expected orb.Collection, got %T", got)
+			}
+
+			if len(gc) != len(tc.gc) {
+				t.Fatalf("member count changed: marshaled %q\n  in  %d members: %v\n  out %d members: %v",
+					s, len(tc.gc), tc.gc, len(gc), gc)
+			}
+
+			if !gc.Equal(tc.gc) {
+				t.Fatalf("round-trip inequality: marshaled %q\n  in  %v\n  out %v", s, tc.gc, gc)
+			}
+
+			// a second marshal must be byte-identical: no member added, lost or reshaped.
+			if again := MarshalString(gc); again != s {
+				t.Fatalf("marshal not idempotent after round-trip:\n  first  %q\n  second %q", s, again)
+			}
+		})
+	}
+}
+
+// TestSplitGeometryCollection covers the member splitter directly, including
+// EMPTY members (no parentheses) and top-level commas inside nested members.
+func TestSplitGeometryCollection(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "single empty member",
+			input:    "(LINESTRING EMPTY)",
+			expected: []string{"LINESTRING EMPTY"},
+		},
+		{
+			name:     "non-empty then empty",
+			input:    "(POINT(1 2),LINESTRING EMPTY)",
+			expected: []string{"POINT(1 2)", "LINESTRING EMPTY"},
+		},
+		{
+			name:     "two non-empty members",
+			input:    "(POINT(1 2),LINESTRING(3 4,5 6))",
+			expected: []string{"POINT(1 2)", "LINESTRING(3 4,5 6)"},
+		},
+		{
+			name:     "nested collection member is not split on its inner comma",
+			input:    "(GEOMETRYCOLLECTION(POINT(1 2),POINT(3 4)),POINT(5 6))",
+			expected: []string{"GEOMETRYCOLLECTION(POINT(1 2),POINT(3 4))", "POINT(5 6)"},
+		},
+		{
+			name:     "multipolygon member with nested commas",
+			input:    "(MULTIPOLYGON(((1 2,3 4)),((5 6,7 8))),POINT(9 0))",
+			expected: []string{"MULTIPOLYGON(((1 2,3 4)),((5 6,7 8)))", "POINT(9 0)"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := splitGeometryCollection(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(got) != len(tc.expected) {
+				t.Fatalf("member count: got %d %v, want %d %v",
+					len(got), got, len(tc.expected), tc.expected)
+			}
+
+			for i := range tc.expected {
+				if got[i] != tc.expected[i] {
+					t.Errorf("member %d: got %q, want %q", i, got[i], tc.expected[i])
+				}
+			}
+		})
+	}
+}

--- a/encoding/wkt/unmarshal.go
+++ b/encoding/wkt/unmarshal.go
@@ -385,17 +385,13 @@ func unmarshalCollection(s string) (orb.Collection, error) {
 		return nil, ErrNotWKT
 	}
 
-	geometries := splitGeometryCollection(s[18:])
-	if len(geometries) == 0 {
-		return orb.Collection{}, nil
+	geometries, err := splitGeometryCollection(s[18:])
+	if err != nil {
+		return nil, err
 	}
 
 	c := make(orb.Collection, 0, len(geometries))
 	for _, g := range geometries {
-		if len(g) == 0 {
-			continue
-		}
-
 		tg, err := Unmarshal(g)
 		if err != nil {
 			return nil, err
@@ -407,30 +403,35 @@ func unmarshalCollection(s string) (orb.Collection, error) {
 	return c, nil
 }
 
-// splitGeometryCollection split GEOMETRYCOLLECTION to more geometry
-func splitGeometryCollection(s string) (r []string) {
-	r = make([]string, 0)
-	stack := make([]rune, 0)
-	l := len(s)
-	for i, v := range s {
-		if !strings.Contains(string(stack), "(") {
-			stack = append(stack, v)
-			continue
-		}
-		if ('A' <= v && v < 'Z') || ('a' <= v && v < 'z') {
-			t := string(stack)
-			r = append(r, t[:len(t)-1])
-			stack = make([]rune, 0)
-			stack = append(stack, v)
-			continue
-		}
-		if i == l-1 {
-			r = append(r, string(stack))
-			continue
-		}
-		stack = append(stack, v)
+// splitGeometryCollection splits the body of a GEOMETRYCOLLECTION into its
+// member WKT strings. Members are separated by top-level commas, and a member
+// may be an EMPTY geometry with no parentheses, so the split tracks bracket
+// depth rather than assuming every member contains a bracket.
+func splitGeometryCollection(s string) ([]string, error) {
+	s, err := trimSpaceBrackets(s)
+	if err != nil {
+		return nil, err
 	}
-	return
+
+	r := make([]string, 0)
+	depth := 0
+	start := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				r = append(r, trimSpace(s[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	r = append(r, trimSpace(s[start:]))
+
+	return r, nil
 }
 
 // Unmarshal return a geometry by parsing the WKT string.


### PR DESCRIPTION
### Problem

`wkt.Marshal` produces spec-valid WKT for a `GEOMETRYCOLLECTION` whose members are EMPTY geometries, but `wkt.Unmarshal` silently drops those members, so the library cannot read back its own output:

```go
gc := orb.Collection{orb.Point{1, 2}, orb.LineString{}}
s := wkt.MarshalString(gc)                 // "GEOMETRYCOLLECTION(POINT(1 2),LINESTRING EMPTY)"
got, _ := wkt.Unmarshal(s)
// got is GEOMETRYCOLLECTION(POINT(1 2)) -- the empty member is gone
```

This reproduces for every empty-capable member type (`LINESTRING`/`POLYGON`/`MULTIPOINT`/`MULTILINESTRING`/`MULTIPOLYGON`/`GEOMETRYCOLLECTION EMPTY`), for mixed empty/non-empty collections, and for nested collections.

### Root cause

`splitGeometryCollection` only appended a member once a `(` had been pushed onto its rune stack. An EMPTY geometry has no parentheses, so its token never triggered a yield and stayed stuck in the stack. `unmarshalCollection` then discarded the resulting `""` via `if len(g) == 0 { continue }`.

For example `splitGeometryCollection("(LINESTRING EMPTY)")` returned `[""]` and `"(POINT(1 2),LINESTRING EMPTY)"` returned `["", "POINT(1 2)"]` -- the empty member vanished.

### Fix

Rewrite the splitter to split the collection body on top-level commas while tracking bracket depth. This treats empty members (no parens) and nested-collection members (inner commas) uniformly, and removes the `len(g)==0` swallow. Non-empty and nested non-empty collections are unaffected.

### Tests

`TestUnmarshalCollection_roundTrip` asserts the `Unmarshal(Marshal(gc)) == gc` self-oracle over each empty-capable type, mixed empty/non-empty, and nested collections, checking member count, member equality and marshal idempotence. `TestSplitGeometryCollection` covers the splitter directly, including nested members whose inner commas must not split. `go test ./...` passes for the affected packages (the pre-existing `simplify` Visvalingam benchmark failure is unrelated and also fails on `master`).